### PR TITLE
Fix converting xml to record type with rest type and required fields

### DIFF
--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -2888,6 +2888,50 @@ function testXmlToRecordWithDefaultValuesForParseAsType2() returns error? {
     test:assertEquals(university.category, "State");
 }
 
+@test:Config
+isolated function testConvertXmlToOpenRecordWithSomeRequiredFields() returns error? {
+    string xmlStr1 = string `
+    <Data>
+        <field2>
+            <str2>2</str2>
+            <str3>3</str3>
+            <str1>1</str1>
+        </field2>
+    </Data>
+    `;
+    record {|
+        record {
+            string str1;
+            float str3;
+        } field2;
+    |} rec1 = check parseString(xmlStr1);
+    test:assertEquals(rec1.field2.str1, "1");
+    test:assertEquals(rec1.field2.str3, 3f);
+    test:assertEquals(rec1.field2.get("str2"), 2);
+
+    string xmlStr2 = string `
+    <Data>
+        <Depth1>
+            <A>1</A>
+            <A>2</A>
+            <B>2</B>
+            <B>5</B>
+        </Depth1>
+        <value>3</value>
+    </Data>
+    `;
+
+    record {|
+        string value;
+        record {|
+            string[] B;
+            int[]...;
+        |}...;
+    |} rec2 = check parseString(xmlStr2);
+    test:assertEquals(rec2.value, "3");
+    test:assertEquals(rec2.get("Depth1"), {A: [1, 2], B: ["2", "5"]});
+}
+
 // Negative cases
 type DataN1 record {|
     int A;

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/Constants.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.lib.data.xmldata.utils;
 
-import io.ballerina.lib.data.xmldata.xml.QualifiedName;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.types.ArrayType;

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/Constants.java
@@ -54,7 +54,6 @@ public class Constants {
     public static final String RECORD = "record";
     public static final String RECORD_OR_MAP = "record or map";
     public static final String ANON_TYPE = "$anonType$";
-    public static final QualifiedName EXIT_REST_POINT = new QualifiedName("", "$exitRestPoint$", "");
     public static final BString ATTRIBUTE_PREFIX = StringUtils.fromString("attributePrefix");
     public static final BString TEXT_FIELD_NAME = StringUtils.fromString("textFieldName");
     public static final BString ALLOW_DATA_PROJECTION = StringUtils.fromString("allowDataProjection");

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
@@ -786,6 +786,29 @@ public class DataUtils {
         return false;
     }
 
+    public static boolean isEqualQualifiedName(QualifiedName firstQName, QualifiedName secondQName) {
+        if (firstQName == null || secondQName == null) {
+            return false;
+        }
+
+        if (firstQName.equals(secondQName)) {
+            return true;
+        }
+
+        return firstQName.getLocalPart().equals(secondQName.getLocalPart())
+                && (firstQName.getNamespaceURI().equals(Constants.NS_ANNOT_NOT_DEFINED)
+                || secondQName.getNamespaceURI().equals(Constants.NS_ANNOT_NOT_DEFINED));
+    }
+
+    public static boolean isSimpleType(Type type) {
+        return switch (type.getTag()) {
+            case TypeTags.JSON_TAG, TypeTags.ANYDATA_TAG, TypeTags.MAP_TAG, TypeTags.OBJECT_TYPE_TAG,
+                    TypeTags.RECORD_TYPE_TAG, TypeTags.XML_TAG -> false;
+            case TypeTags.ARRAY_TAG -> isSimpleType(((ArrayType) type).getElementType());
+            default -> true;
+        };
+    }
+
     /**
      * Holds data required for the traversing.
      *

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
@@ -912,6 +912,7 @@ public class DataUtils {
             case TypeTags.JSON_TAG, TypeTags.ANYDATA_TAG, TypeTags.MAP_TAG, TypeTags.OBJECT_TYPE_TAG,
                     TypeTags.RECORD_TYPE_TAG, TypeTags.XML_TAG -> false;
             case TypeTags.ARRAY_TAG -> isSimpleType(((ArrayType) type).getElementType());
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG -> isSimpleType(((ReferenceType) type).getReferredType());
             default -> true;
         };
     }


### PR DESCRIPTION
## Purpose

Fixes: [#6659](https://github.com/ballerina-platform/ballerina-library/issues/6659)

```

public function main() returns error? {
    string xmlStr = string `
    <Data>
        <field2>
            <str2>2</str2>
            <str1>1</str1>
        </field2>
    </Data>
    `;
    record {|
        record {
            string str1;
        } field2;
    |} rec = check xmldata:parseString(xmlStr);
}
```
In the above case issue is element `str1` is convert to anydata (`int` runtime value) instead of string. This is due to the all the elements after `str2` convert to the rest type. In this PR we have fixed this wrong behaviour.

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
