### PR TITLE
Expose fromJson api

### DIFF
--- a/ballerina/xml_api.bal
+++ b/ballerina/xml_api.bal
@@ -178,7 +178,7 @@ type JsonOptions record {|
 # + jsonValue - The JSON source to be converted to XML
 # + options - The `xmldata:JsonOptions` record for JSON to XML conversion properties
 # + return - XML representation of the given JSON if the JSON is successfully converted or else an `xmldata:Error`.
-isolated function fromJson(json jsonValue, JsonOptions options = {}) returns xml|Error {
+public isolated function fromJson(json jsonValue, JsonOptions options = {}) returns xml|Error {
     string? rootTag = options.rootTag;
     map<string> allNamespaces = {};
     if !isSingleNode(jsonValue) {


### PR DESCRIPTION
## Purpose
fromJson api from `xmldata` module is used in library modules as dependency. Once we release stable version of `data.xmldata`, `xmldata` can be deprecated hence making this api public to support that use case.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
