### PR TITLE
Fix issues regarding finites type with byte values

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0-20241204-083100-fb56dd82"
+distribution-version = "2201.11.0-20241121-075100-c4c87cbc"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0-20241204-083100-fb56dd82"
+distribution-version = "2201.11.0-20241204-163800-0d1e4836"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0-20241121-075100-c4c87cbc"
+distribution-version = "2201.11.0-20241204-083100-fb56dd82"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/tests/test_finite_types.bal
+++ b/ballerina/tests/test_finite_types.bal
@@ -24,7 +24,7 @@ enum EnumA {
 
 type FiniteType true|"A"|1|2;
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypes() returns error? {
     record {| 
         EnumA a;
@@ -37,7 +37,7 @@ function testFiniteTypes() returns error? {
     test:assertEquals(r, {a: "A", b: "B", nested: {c: "B", d: "B"}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypesWithNestedRecords() returns error? {
     record {| 
         EnumA a;
@@ -51,7 +51,7 @@ function testFiniteTypesWithNestedRecords() returns error? {
     test:assertEquals(r, {a: "C2", b: 1, nested: {c: 2, d: "A", e: true}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypeArrays() returns error? {
     record {| 
         EnumA[] a;
@@ -64,7 +64,7 @@ function testFiniteTypeArrays() returns error? {
     test:assertEquals(r, {a: ["A", "A"], b: ["B", "B"], nested: {c: ["B", "B"], d: ["B", "B"]}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypeArrays2() returns error? {
     record {| 
         EnumA[] a;
@@ -78,7 +78,7 @@ function testFiniteTypeArrays2() returns error? {
     test:assertEquals(r, {a: ["C2", "C2"], b: [1, 1], nested: {c: [2, 2], d: ["A", "A"], e: [true, true]}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypesWithXmlString() returns error? {
     record {| 
         EnumA a;
@@ -91,7 +91,7 @@ function testFiniteTypesWithXmlString() returns error? {
     test:assertEquals(r, {a: "A", b: "B", nested: {c: "B", d: "B"}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypesWithNestedRecordsWithXmlString() returns error? {
     record {| 
         EnumA a;
@@ -105,7 +105,7 @@ function testFiniteTypesWithNestedRecordsWithXmlString() returns error? {
     test:assertEquals(r, {a: "C2", b: 1, nested: {c: 2, d: "A", e: true}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypeArraysWithXmlString() returns error? {
     record {| 
         EnumA[] a;
@@ -118,7 +118,7 @@ function testFiniteTypeArraysWithXmlString() returns error? {
     test:assertEquals(r, {a: ["A", "A"], b: ["B", "B"], nested: {c: ["B", "B"], d: ["B", "B"]}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypeArraysWithXmlString2() returns error? {
     record {| 
         EnumA[] a;
@@ -143,7 +143,7 @@ type NestedRec record {|
     EnumA d;
 |};
 
-@test:Config {enable: false}
+@test:Config
 function testFiniteTypesWithNameAnnotations() returns error? {
     record {|
         EnumA a;
@@ -155,7 +155,7 @@ function testFiniteTypesWithNameAnnotations() returns error? {
 
 type FiniteValue 100f;
 
-@test:Config {enable: false}
+@test:Config
 function testRecordFieldWithSingleFiniteType() returns error? {
     record {| 
         EnumA a;
@@ -168,7 +168,7 @@ function testRecordFieldWithSingleFiniteType() returns error? {
     test:assertEquals(r, {a: "A", b: "A", nested: {c: 100f, d: "B"}});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testRecordFieldWithSingleFiniteType2() returns error? {
     record {| 
         100f a;
@@ -183,7 +183,7 @@ function testRecordFieldWithSingleFiniteType2() returns error? {
     test:assertEquals(r, {a: 100f, b: 200.1d, c: 100d, d: 200.1f, e: 100f, f: 200.1d, g: 100d, h: 200.1f});
 }
 
-@test:Config {enable: false}
+@test:Config
 function testRecordFieldWithSingleFiniteType3() returns error? {
     record {| 
         100f a;
@@ -198,7 +198,7 @@ function testRecordFieldWithSingleFiniteType3() returns error? {
     test:assertEquals((<Error>r2).message(), "'string' value '100.01' cannot be converted to '100d'");
 }
 
-@test:Config {enable: false}
+@test:Config
 function testRecordFieldWithSingleFiniteType4() returns error? {
     record {| 
         200.1d|100f a;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
 version=1.2.0-SNAPSHOT
-ballerinaLangVersion=2201.11.0-20241121-075100-c4c87cbc
+ballerinaLangVersion=2201.11.0-20241204-083100-fb56dd82
 
 checkstyleToolVersion=10.12.0
 puppycrawlCheckstyleVersion=10.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
 version=1.2.0-SNAPSHOT
-ballerinaLangVersion=2201.11.0-20241204-083100-fb56dd82
+ballerinaLangVersion=2201.11.0-20241204-163800-0d1e4836
 
 checkstyleToolVersion=10.12.0
 puppycrawlCheckstyleVersion=10.12.0

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/FromString.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/FromString.java
@@ -40,6 +40,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import static io.ballerina.runtime.api.constants.RuntimeConstants.BBYTE_MAX_VALUE;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.BBYTE_MIN_VALUE;
+
 /**
  * Native implementation of data:fromStringWithType(string).
  *
@@ -79,16 +82,22 @@ public class FromString {
 
     public static Object fromStringWithType(BString string, Type expType) {
         String value = string.getValue();
+        int tag = expType.getTag();
+
         try {
-            switch (expType.getTag()) {
+            if (TypeTags.isStringTypeTag(tag)) {
+                return string;
+            }
+
+            switch (tag) {
                 case TypeTags.INT_TAG:
                     return stringToInt(value);
+                case TypeTags.BYTE_TAG:
+                    return stringToByte(value);
                 case TypeTags.FLOAT_TAG:
                     return stringToFloat(value);
                 case TypeTags.DECIMAL_TAG:
                     return stringToDecimal(value);
-                case TypeTags.STRING_TAG:
-                    return string;
                 case TypeTags.BOOLEAN_TAG:
                     return stringToBoolean(value);
                 case TypeTags.NULL_TAG:
@@ -143,6 +152,19 @@ public class FromString {
 
     private static Long stringToInt(String value) throws NumberFormatException {
         return Long.parseLong(value);
+    }
+
+    private static int stringToByte(String value) throws NumberFormatException {
+        Long number = Long.parseLong(value);
+        int intValue = number.intValue();
+        if (isByteLiteral(intValue)) {
+            return intValue;
+        }
+        throw new NumberFormatException();
+    }
+
+    private static boolean isByteLiteral(long longValue) {
+        return (longValue >= BBYTE_MIN_VALUE && longValue <= BBYTE_MAX_VALUE);
     }
 
     private static Double stringToFloat(String value) throws NumberFormatException {


### PR DESCRIPTION
This PR is due to the failures in https://github.com/ballerina-platform/ballerina-lang/actions/runs/12150965444/job/33884989518?pr=43606.

With the new semtype changes, few behaviours are changed in finite types.

Consider a Singleton type like following
```
type FiniteType true|"A"|1|2;
``` 
 Before semtype, this value `1`(inside the finite type) is treated as a Long, after semtype it is treated as a `Integer` in runtime.
So the output of the `TypeUtils.getType` is different in the twocases.
Thats the reason for the test failures