### PR TITLE
Allow map type as the expected type with parseAsType

### DIFF
--- a/ballerina/tests/parse_map.bal
+++ b/ballerina/tests/parse_map.bal
@@ -1,10 +1,54 @@
 import ballerina/test;
 
+type M map<anydata>;
+
+type R record {|
+    anydata...;
+|};
+
 @test:Config
 function testParseMapAnyData() {
     xml xmlValue = xml `<root> <foo>5</foo> <bar>10</bar> </root>`;
     map<anydata> mapValue = checkpanic parseAsType(xmlValue);
-    // record {|anydata...;|} mapValue = checkpanic parseAsType(xmlValue);
-    test:assertEquals({"foo": 5, "bar": 10}, mapValue, msg = "Parsed map value is not as expected");
-    // TODO: also test type alias, union etc.
+    test:assertEquals({"foo": 5, "bar": 10}, mapValue);
+    M mapValue2 = checkpanic parseAsType(xmlValue);
+    test:assertEquals(mapValue, mapValue2);
+    R recordValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals(mapValue, recordValue);
+}
+
+@test:Config
+function testParseUnion() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar>foo</bar> </root>`;
+    map<int>|map<string>|map<anydata> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertTrue(mapValue is map<string>);
+    test:assertEquals({"foo": "5", "bar": "foo"}, mapValue);
+}
+
+@test:Config
+function testParseUnion2() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar>foo</bar> </root>`;
+    map<int|string> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": 5, "bar": "foo"}, mapValue);
+}
+
+@test:Config
+function testParseUnion3() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar>true</bar> </root>`;
+    map<int>|map<boolean>|map<string> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": "5", "bar": "true"}, mapValue);
+}
+
+@test:Config
+function testParseBooleanMap() {
+    xml xmlValue = xml `<root> <foo>true</foo> <bar>false</bar> </root>`;
+    map<boolean> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": true, "bar": false}, mapValue);
+}
+
+@test:Config
+function testParseIntMap() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar>10</bar> </root>`;
+    map<int> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": 5, "bar": 10}, mapValue);
 }

--- a/ballerina/tests/parse_map.bal
+++ b/ballerina/tests/parse_map.bal
@@ -52,3 +52,53 @@ function testParseIntMap() {
     map<int> mapValue = checkpanic parseAsType(xmlValue);
     test:assertEquals({"foo": 5, "bar": 10}, mapValue);
 }
+
+// https://github.com/ballerina-platform/ballerina-library/issues/7896
+@test:Config {enable: false}
+function testParseNullableIntMap() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar>10</bar> <baz></baz> </root>`;
+    map<int?> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": 5, "bar": 10, "baz": ()}, mapValue);
+}
+
+// https://github.com/ballerina-platform/ballerina-library/issues/7896
+@test:Config {enable: false}
+function testParseNullableIntMapWithNullValues() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar></bar> <baz>15</baz> </root>`;
+    map<int?> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({foo: 5, bar: (), baz: 15}, mapValue);
+}
+
+// https://github.com/ballerina-platform/ballerina-library/issues/7896
+@test:Config {enable: false}
+function testParseNullableIntMapWithAttributes() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"></bar> <baz>15</baz> </root>`;
+    map<int?> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": 5, "bar": (), "baz": 15}, mapValue);
+}
+
+// https://github.com/ballerina-platform/ballerina-library/issues/7896
+@test:Config {enable: false}
+function testParseUnionWithNullable() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar></bar> <baz>15</baz> </root>`;
+    map<int?>|map<string?> mapValue = checkpanic parseAsType(xmlValue);
+    test:assertTrue(mapValue is map<int?>);
+    test:assertEquals({"foo": 5, "bar": (), "baz": 15}, mapValue);
+}
+
+type R2 record {|
+    R1...;
+|};
+
+type R1 record {|
+    int foo;
+    string bar;
+|};
+
+// https://github.com/ballerina-platform/ballerina-library/issues/7897
+@test:Config {enable: false}
+function testNestedRecord() {
+    xml xmlValue1 = xml `<root><v1> <foo>5</foo> <bar>10</bar> </v1></root>`;
+    R2 mapValue2 = checkpanic parseAsType(xmlValue1);
+    test:assertEquals({"v1": {foo: 5, bar: "10"}}, mapValue2);
+}

--- a/ballerina/tests/parse_map.bal
+++ b/ballerina/tests/parse_map.bal
@@ -1,3 +1,18 @@
+// Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License
 import ballerina/test;
 
 type M map<anydata>;

--- a/ballerina/tests/parse_map.bal
+++ b/ballerina/tests/parse_map.bal
@@ -1,0 +1,10 @@
+import ballerina/test;
+
+@test:Config
+function testParseMapAnyData() {
+    xml xmlValue = xml `<root> <foo>5</foo> <bar>10</bar> </root>`;
+    map<anydata> mapValue = checkpanic parseAsType(xmlValue);
+    // record {|anydata...;|} mapValue = checkpanic parseAsType(xmlValue);
+    test:assertEquals({"foo": 5, "bar": 10}, mapValue, msg = "Parsed map value is not as expected");
+    // TODO: also test type alias, union etc.
+}

--- a/compiler-plugin/src/main/java/io/ballerina/lib/data/xmldata/compiler/XmldataRecordFieldValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/lib/data/xmldata/compiler/XmldataRecordFieldValidator.java
@@ -232,7 +232,7 @@ public class XmldataRecordFieldValidator implements AnalysisTask<SyntaxNodeAnaly
 
     private boolean isNotValidExpectedType(TypeSymbol typeSymbol) {
         switch (typeSymbol.typeKind()) {
-            case RECORD -> {
+            case RECORD, MAP -> {
                 return false;
             }
             case TYPE_REFERENCE -> {

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
@@ -117,7 +117,8 @@ public class XmlTraversal {
         
         private Object traverseXmlWithRecordAsExpectedType(BXml xml, XmlAnalyzerData analyzerData,
                                                            RecordType recordType) {
-            analyzerData.currentNode = ValueCreator.createRecordValue(recordType.getPackage(), recordType.getName());
+            analyzerData.currentNode = recordType.getPackage() == null ? ValueCreator.createRecordValue(recordType) :
+                    ValueCreator.createRecordValue(recordType.getPackage(), recordType.getName());
             BXml nextXml = validateRootElement(xml, recordType, analyzerData);
             Object resultRecordValue = traverseXml(nextXml, recordType, analyzerData);
             validateModelGroupStackForRootElement(analyzerData);


### PR DESCRIPTION
## Purpose
$subject
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7333

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
