### PR TITLE
Support same xml element names with different namespaces for `toXml` API

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["Ballerina"]
 keywords = ["xml"]
 repository = "https://github.com/ballerina-platform/module-ballerina-data-xmldata"
@@ -12,8 +12,8 @@ export = ["data.xmldata"]
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "data-native"
-version = "1.4.2"
-path = "../native/build/libs/data.xmldata-native-1.4.2.jar"
+version = "1.4.3"
+path = "../native/build/libs/data.xmldata-native-1.4.3-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "constraint-compiler-plugin"
 class = "io.ballerina.lib.data.xmldata.compiler.XmldataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/data.xmldata-compiler-plugin-1.4.2.jar"
+path = "../compiler-plugin/build/libs/data.xmldata-compiler-plugin-1.4.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/tests/toXml_test.bal
+++ b/ballerina/tests/toXml_test.bal
@@ -1802,6 +1802,50 @@ function testNestedXmlElementWithDifferentNamespaces() returns error? {
     test:assertEquals(recValue, orderData, string `expected: ${recValue.toString()}, actual: ${orderData.toString()}`);
 }
 
+@Name {
+    value: "Order"
+}
+type NestedRecordWithNamespaces2 record {|
+    @Name {
+        value: "Product"
+    }
+    ProductDetails product;
+|};
+
+@test:Config {
+    groups: ["toXml", "nested"]
+}
+function testNestedXmlElementWithDifferentNamespaces2() returns error? {
+    ProductDetails productData = {
+        retailerTitle: "Cloud Native Development",
+        publisherTitle: "Cloud Native Development: A Practical Guide",
+        price: 49.99
+    };
+    NestedRecordWithNamespaces2 orderData = {
+        product: productData
+    };
+
+    xml result = check toXml(orderData);
+    string xmlStr = "<Order>" +
+                        "<Product>" +
+                            "<retail:title xmlns:retail=\"http://example.com/retailer\">Cloud Native Development</retail:title>" +
+                            "<pub:title xmlns:pub=\"http://example.com/publisher\">Cloud Native Development: A Practical Guide</pub:title>" +
+                            "<retail:price xmlns:retail=\"http://example.com/retailer\">49.99</retail:price>" +
+                        "</Product>" +
+                    "</Order>";
+    test:assertEquals(result.toString(), xmlStr, string `expected: ${xmlStr}, actual: ${result.toString()}`);
+
+    xml xmlValue = xml `<Order xmlns:retail="http://example.com/retailer" xmlns:pub="http://example.com/publisher">
+                        <Product>
+                            <retail:title>Cloud Native Development</retail:title>
+                            <pub:title>Cloud Native Development: A Practical Guide</pub:title>
+                            <retail:price>49.99</retail:price>
+                        </Product>
+                    </Order>`;
+    NestedRecordWithNamespaces2 recValue = check parseAsType(xmlValue);
+    test:assertEquals(recValue, orderData, string `expected: ${recValue.toString()}, actual: ${orderData.toString()}`);
+}
+
 type IdRecord record {|
     @Name {value: "CompanyId"}
     string id;

--- a/ballerina/tests/toXml_test.bal
+++ b/ballerina/tests/toXml_test.bal
@@ -1655,3 +1655,239 @@ function testToXmlWithRestTypes2() returns error? {
     test:assertTrue(xmlItem is xml:Element);
     test:assertEquals(xmlItem.toString(), xmlStr);
 }
+
+@Name {
+    value: "CompanyDetails"
+}
+type RecordWithNamespaces record {|
+    @Name {
+        value: "CompanyId"
+    }
+    string id;
+
+    @Name {
+        value: "CompanyAddress"
+    }
+    @Namespace {
+        prefix: "company",
+        uri: "http://example.com/company"
+    }
+    string address;
+
+    @Name {
+        value: "name"
+    }
+    @Namespace {
+        prefix: "employee",
+        uri: "http://example.com/employee"
+    }
+    string employeeName;
+
+    @Name {
+        value: "name"
+    }
+    @Namespace {
+        prefix: "company",
+        uri: "http://example.com/company"
+    }
+    string companyName;
+
+    string remarks;
+|};
+
+@test:Config {
+    groups: ["toXml"]
+}
+function testSameXmlElementWithDifferentNamespaces() returns error? {
+    RecordWithNamespaces data = {
+        id: "123",
+        address: "123 Main St",
+        employeeName: "John Doe",
+        companyName: "Tech Corp",
+        remarks: "No remarks"
+    };
+
+    xml result = check toXml(data);
+    string xmlStr = "<CompanyDetails>" +
+                        "<CompanyId>123</CompanyId>" +
+                        "<company:CompanyAddress xmlns:company=\"http://example.com/company\">123 Main St</company:CompanyAddress>" +
+                        "<employee:name xmlns:employee=\"http://example.com/employee\">John Doe</employee:name>" +
+                        "<company:name xmlns:company=\"http://example.com/company\">Tech Corp</company:name>" +
+                        "<remarks>No remarks</remarks>" +
+                    "</CompanyDetails>";
+    test:assertEquals(result.toString(), xmlStr, string `expected: ${xmlStr}, actual: ${result.toString()}`);
+
+    xml xmlValue = xml `<CompanyDetails xmlns:company="http://example.com/company" xmlns:employee="http://example.com/employee">
+                        <CompanyId>123</CompanyId>
+                        <company:CompanyAddress>123 Main St</company:CompanyAddress>
+                        <employee:name >John Doe</employee:name>
+                        <company:name>Tech Corp</company:name>
+                        <remarks>No remarks</remarks>
+                    </CompanyDetails>`;
+    RecordWithNamespaces recValue = check parseAsType(xmlValue);
+    test:assertEquals(recValue, data, string `expected: ${recValue.toString()}, actual: ${data.toString()}`);
+}
+
+type ProductDetails record {|
+    @Name {
+        value: "title"
+    }
+    @Namespace {
+        prefix: "retail",
+        uri: "http://example.com/retailer"
+    }
+    string retailerTitle;
+
+    @Name {
+        value: "title"
+    }
+    @Namespace {
+        prefix: "pub",
+        uri: "http://example.com/publisher"
+    }
+    string publisherTitle;
+
+    @Namespace {
+        prefix: "retail",
+        uri: "http://example.com/retailer"
+    }
+    decimal price;
+|};
+
+@Name {
+    value: "Order"
+}
+type NestedRecordWithNamespaces record {|
+    string orderId;
+    @Name {
+        value: "Product"
+    }
+    ProductDetails product;
+|};
+
+@test:Config {
+    groups: ["toXml", "nested"]
+}
+function testNestedXmlElementWithDifferentNamespaces() returns error? {
+    ProductDetails productData = {
+        retailerTitle: "Cloud Native Development",
+        publisherTitle: "Cloud Native Development: A Practical Guide",
+        price: 49.99
+    };
+    NestedRecordWithNamespaces orderData = {
+        orderId: "ORD-9876",
+        product: productData
+    };
+
+    xml result = check toXml(orderData);
+    string xmlStr = "<Order>" +
+                        "<orderId>ORD-9876</orderId>" +
+                        "<Product>" +
+                            "<retail:title xmlns:retail=\"http://example.com/retailer\">Cloud Native Development</retail:title>" +
+                            "<pub:title xmlns:pub=\"http://example.com/publisher\">Cloud Native Development: A Practical Guide</pub:title>" +
+                            "<retail:price xmlns:retail=\"http://example.com/retailer\">49.99</retail:price>" +
+                        "</Product>" +
+                    "</Order>";
+    test:assertEquals(result.toString(), xmlStr, string `expected: ${xmlStr}, actual: ${result.toString()}`);
+
+    xml xmlValue = xml `<Order xmlns:retail="http://example.com/retailer" xmlns:pub="http://example.com/publisher">
+                        <orderId>ORD-9876</orderId>
+                        <Product>
+                            <retail:title>Cloud Native Development</retail:title>
+                            <pub:title>Cloud Native Development: A Practical Guide</pub:title>
+                            <retail:price>49.99</retail:price>
+                        </Product>
+                    </Order>`;
+    NestedRecordWithNamespaces recValue = check parseAsType(xmlValue);
+    test:assertEquals(recValue, orderData, string `expected: ${recValue.toString()}, actual: ${orderData.toString()}`);
+}
+
+type IdRecord record {|
+    @Name {value: "CompanyId"}
+    string id;
+|};
+
+type AddressRecord record {|
+    @Name {value: "CompanyAddress"}
+    @Namespace {prefix: "company", uri: "http://example.com/company"}
+    string address;
+|};
+
+type EmployeeNameRecord record {|
+    @Name {value: "name"}
+    @Namespace {prefix: "employee", uri: "http://example.com/employee"}
+    string employeeName;
+|};
+
+type CompanyNameRecord record {|
+    @Name {value: "name"}
+    @Namespace {prefix: "company", uri: "http://example.com/company"}
+    string companyName;
+|};
+
+type RemarksRecord record {|
+    string remarks;
+|};
+
+@Name {
+    value: "CompanyDetails"
+}
+type FullyNestedRecord record {|
+    @Name { value: "Identification" }
+    IdRecord idInfo;
+
+    @Name { value: "Location" }
+    AddressRecord addressInfo;
+
+    @Name { value: "Personnel" }
+    EmployeeNameRecord employeeInfo;
+
+    @Name { value: "Organization" }
+    CompanyNameRecord companyInfo;
+    
+    @Name { value: "Notes" }
+    RemarksRecord remarksInfo;
+|};
+
+@test:Config {
+    groups: ["toXml", "nested"]
+}
+function testFullyNestedXmlElementWithDifferentNamespaces() returns error? {
+    FullyNestedRecord data = {
+        idInfo: { id: "123" },
+        addressInfo: { address: "123 Main St, Colombo" },
+        employeeInfo: { employeeName: "John Doe" },
+        companyInfo: { companyName: "Tech Corp" },
+        remarksInfo: { remarks: "No remarks" }
+    };
+
+    xml result = check toXml(data);
+    string xmlStr = "<CompanyDetails>" + 
+                        "<Identification><CompanyId>123</CompanyId></Identification>" +
+                        "<Location><company:CompanyAddress xmlns:company=\"http://example.com/company\">123 Main St, Colombo</company:CompanyAddress></Location>" +
+                        "<Personnel><employee:name xmlns:employee=\"http://example.com/employee\">John Doe</employee:name></Personnel>" +
+                        "<Organization><company:name xmlns:company=\"http://example.com/company\">Tech Corp</company:name></Organization>" +
+                        "<Notes><remarks>No remarks</remarks></Notes>" +
+                    "</CompanyDetails>";
+    test:assertEquals(result.toString(), xmlStr, string `expected: ${xmlStr}, actual: ${result.toString()}`);
+
+    xml xmlValue = xml `<CompanyDetails xmlns:company="http://example.com/company" xmlns:employee="http://example.com/employee">
+                        <Identification>
+                            <CompanyId>123</CompanyId>
+                        </Identification>
+                        <Location>
+                            <company:CompanyAddress>123 Main St, Colombo</company:CompanyAddress>
+                        </Location>
+                        <Personnel>
+                            <employee:name>John Doe</employee:name>
+                        </Personnel>
+                        <Organization>
+                            <company:name>Tech Corp</company:name>
+                        </Organization>
+                        <Notes>
+                            <remarks>No remarks</remarks>
+                        </Notes>
+                    </CompanyDetails>`;
+    FullyNestedRecord recValue = check parseAsType(xmlValue);
+    test:assertEquals(recValue, data, string `expected: ${recValue.toString()}, actual: ${data.toString()}`);
+}

--- a/ballerina/tests/union_error_tests.bal
+++ b/ballerina/tests/union_error_tests.bal
@@ -71,6 +71,10 @@ type F111 record {
         uri: "http://example.com/ns1"
     }
     string b1;
+    @Namespace {
+        prefix: "ns2",
+        uri: "http://example.com/ns1"
+    }
     (G111|G112)[] C;
 };
 
@@ -84,6 +88,10 @@ type F112 record {
         uri: "http://example.com/ns1"
     }
     string b1;
+    @Namespace {
+        prefix: "ns2",
+        uri: "http://example.com/ns1"
+    }
     (G111|G112)[] C;
 };
 

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
@@ -63,7 +63,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 
@@ -120,6 +119,15 @@ public class DataUtils {
 
     public static void validateTypeNamespace(String prefix, String uri, RecordType recordType) {
         ArrayList<String> namespace = getNamespace(recordType);
+        int size = namespace.size();
+        if (size == 0) {
+            return;
+        }
+
+        if (size == 1 && uri.equals(namespace.get(0))) {
+            return;
+        }
+
         if (namespace.isEmpty() || prefix.equals(namespace.get(0)) && uri.equals(namespace.get(1))) {
             return;
         }
@@ -133,8 +141,10 @@ public class DataUtils {
         for (BString annotationsKey : annotations.getKeys()) {
             if (isNamespaceAnnotationKey(annotationsKey.getValue())) {
                 BMap<BString, Object> namespaceAnnotation = (BMap<BString, Object>) annotations.get(annotationsKey);
-                namespace.add(namespaceAnnotation.containsKey(Constants.PREFIX) ?
-                        ((BString) namespaceAnnotation.get(Constants.PREFIX)).getValue() : "");
+                boolean isContainsPrefix = namespaceAnnotation.containsKey(Constants.PREFIX);
+                if (isContainsPrefix) {
+                    namespace.add(((BString) namespaceAnnotation.get(Constants.PREFIX)).getValue());
+                }
                 namespace.add(((BString) namespaceAnnotation.get(Constants.URI)).getValue());
                 break;
             }
@@ -724,7 +734,6 @@ public class DataUtils {
             String keyName = fieldKey.getValue();
             if (isNamespaceAnnotationKey(keyName) || isNameAnnotationKey(keyName)) {
                 nsFieldAnnotation.put(fieldKey, annotationValue.get(fieldKey));
-                break;
             }
         }
         return nsFieldAnnotation;
@@ -1494,23 +1503,5 @@ public class DataUtils {
     }
 
     record FieldAnnotationValue(String elementName, String namespaceUri) {
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o instanceof String str) {
-                return this.elementName.equals(str);
-            }
-            if (!(o instanceof FieldAnnotationValue that)) {
-                return false;
-            }
-            return Objects.equals(this.elementName, that.elementName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(elementName);
-        }
     }
 }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -94,7 +94,7 @@ public class ToXmlUtils {
 
             BString key = jMap.getKeys()[0];
             String keyStr = key.getValue();
-            HashMap<String, String> elementNamesMap = DataUtils.getElementNameMap(referredType);
+            HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = DataUtils.getElementNameMap(referredType);
             ArrayList<String> sequenceFieldNames = getSequenceFieldNames(referredType, elementNamesMap);
             HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames =
                     getModelGroupRelatedFieldNames(referredType, elementNamesMap);
@@ -157,7 +157,7 @@ public class ToXmlUtils {
         BXml xNode = ValueCreator.createXmlValue(Constants.EMPTY_STRING);
         String attributePrefix = options.get(Constants.ATTRIBUTE_PREFIX).toString();
         Type referredType = TypeUtils.getReferredType(type);
-        HashMap<String, String> elementNamesMap = DataUtils.getElementNameMap(referredType);
+        HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = DataUtils.getElementNameMap(referredType);
         HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames =
                 getModelGroupRelatedFieldNames(referredType, elementNamesMap);
         HashMap<String, ElementInfo> elementInfoRelatedFieldNames =
@@ -270,7 +270,7 @@ public class ToXmlUtils {
 
     private static void validateChoiceFields(ModelGroupInfo parentModelGroupInfo, BMap jMap,
                                             HashMap<String, ElementInfo> elementInfoRelatedFieldNames,
-                                            HashMap<String, String> elementNamesMap) {
+                                            HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap) {
         // TODO: Update this later for validate choices with multiple element occurences.
         boolean isMeasurable = true;
         int occurences = 0;
@@ -306,7 +306,7 @@ public class ToXmlUtils {
     }
 
     private static HashMap<String, ModelGroupInfo> getModelGroupRelatedFieldNames(Type expType,
-                                                      HashMap<String, String> elementNamesMap) {
+                                                  HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap) {
         Type referedType = TypeUtils.getReferredType(expType);
         if (referedType instanceof RecordType recordType) {
             return DataUtils.getFieldNamesWithModelGroupAnnotations(recordType, elementNamesMap);
@@ -315,7 +315,7 @@ public class ToXmlUtils {
     }
 
     private static HashMap<String, ElementInfo> getElementInfoRelatedFieldNames(Type expType,
-                                                                          HashMap<String, String> elementNamesMap) {
+                                          HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap) {
         Type referedType = TypeUtils.getReferredType(expType);
         if (referedType instanceof RecordType recordType) {
             return DataUtils.getFieldNamesWithElementGroupAnnotations(recordType, elementNamesMap, null);
@@ -324,7 +324,7 @@ public class ToXmlUtils {
     }
 
     private static ArrayList<String> getSequenceFieldNames(Type expType,
-                                                                    HashMap<String, String> elementNamesMap) {
+                                    HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap) {
         Type referedType = TypeUtils.getReferredType(expType);
         if (referedType instanceof RecordType recordType) {
             return DataUtils.getFieldNamesWithSequenceAnnotations(recordType, elementNamesMap);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/QualifiedNameMap.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/QualifiedNameMap.java
@@ -92,8 +92,7 @@ public class QualifiedNameMap<V> {
             return null;
         }
         for (QualifiedName qualifiedName : stringToQNameMap.get(localName)) {
-            if (DataUtils.isSameNamespace(qualifiedName, qName)
-                    && DataUtils.isSameAttributeFlag(qualifiedName.getAttributeState(), qName.getAttributeState())) {
+            if (DataUtils.isSameNamespace(qualifiedName, qName)) {
                 return members.get(qualifiedName);
             }
         }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
@@ -495,7 +495,8 @@ public class XmlTraversal {
             BMap<BString, Object> nextValue =
                     updateNextMappingValue(recordType, fieldName, fieldType, currentMapValue, analyzerData);
             QName qName = xmlItem.getQName();
-            DataUtils.validateTypeNamespace(qName.getPrefix(), qName.getNamespaceURI(), recordType);
+            DataUtils.validateTypeNamespaceForNextRecord(qName.getPrefix(), qName.getNamespaceURI(),
+                    recordType, analyzerData.rootRecord, fieldName);
             handleAttributes(xmlItem, nextValue, analyzerData);
             return nextValue;
         }


### PR DESCRIPTION
Support same xml element names with different namespaces for `toXml` API

Fixes https://github.com/ballerina-platform/ballerina-library/issues/8140
Fixes https://github.com/ballerina-platform/ballerina-library/issues/8151
