### PR TITLE
Support nested sequences and choices in xml values

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Ballerina"]
 keywords = ["xml"]
 repository = "https://github.com/ballerina-platform/module-ballerina-data-xmldata"
@@ -14,8 +14,8 @@ export = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "data-native"
-version = "1.6.1"
-path = "../native/build/libs/data.xmldata-native-1.6.1.jar"
+version = "1.6.2"
+path = "../native/build/libs/data.xmldata-native-1.6.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "constraint-compiler-plugin"
 class = "io.ballerina.lib.data.xmldata.compiler.XmldataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/data.xmldata-compiler-plugin-1.6.1.jar"
+path = "../compiler-plugin/build/libs/data.xmldata-compiler-plugin-1.6.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/tests/xsd_choice_array_test.bal
+++ b/ballerina/tests/xsd_choice_array_test.bal
@@ -410,3 +410,112 @@ function testXsdChoiceArrayFieldWithChildArray() returns error? {
     test:assertTrue(errorValue is Error);
     test:assertEquals((<Error>errorValue).message(), "'choice_XsdChoiceArrayFieldWithChildArray' occurs more than the max allowed times");
 }
+
+type XsdChoiceArrayWithNestedSeq record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 2
+    }
+    ChoiceArrNestedSeqItem[] choice_arr_nested_seq;
+|};
+
+type ChoiceArrNestedSeqItem record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqInsideChoiceArr seq_in_arr?;
+    string direct?;
+|};
+
+type SeqInsideChoiceArr record {|
+    @SequenceOrder {value: 1}
+    string p;
+
+    @SequenceOrder {value: 2}
+    string q;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceArrayWithNestedSeq() returns error? {
+    string xmlStr;
+    XsdChoiceArrayWithNestedSeq|Error v;
+
+    xmlStr = string `<Root><p>hello</p><q>world</q></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_seq: [{seq_in_arr: {p: "hello", q: "world"}}]});
+
+    xmlStr = string `<Root><direct>test</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_seq: [{direct: "test"}]});
+
+    xmlStr = string `<Root><p>hello</p><q>world</q><direct>test</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_seq: [{seq_in_arr: {p: "hello", q: "world"}}, {direct: "test"}]});
+
+    xmlStr = string `<Root><p>hello</p><q>world</q><direct>test</direct><p>foo</p><q>bar</q></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_arr_nested_seq' occurs more than the max allowed times");
+
+    xmlStr = string `<Root></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "required field 'choice_arr_nested_seq' not present in XML");
+}
+
+type XsdChoiceArrayWithNestedChoice record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 2
+    }
+    ChoiceArrNestedChoiceItem[] choice_arr_nested_ch;
+|};
+
+type ChoiceArrNestedChoiceItem record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceInArr inner_ch?;
+    string direct?;
+|};
+
+type InnerChoiceInArr record {|
+    string x?;
+    string y?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceArrayWithNestedChoice() returns error? {
+    string xmlStr;
+    XsdChoiceArrayWithNestedChoice|Error v;
+
+    xmlStr = string `<Root><x>foo</x></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_ch: [{inner_ch: {x: "foo"}}]});
+
+    xmlStr = string `<Root><direct>test</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_ch: [{direct: "test"}]});
+
+    xmlStr = string `<Root><x>foo</x><direct>test</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_ch: [{inner_ch: {x: "foo"}}, {direct: "test"}]});
+
+    xmlStr = string `<Root><x>foo</x><direct>test</direct><y>bar</y></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_arr_nested_ch' occurs more than the max allowed times");
+
+    xmlStr = string `<Root></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "required field 'choice_arr_nested_ch' not present in XML");
+}

--- a/ballerina/tests/xsd_choice_array_test_with_parse_type.bal
+++ b/ballerina/tests/xsd_choice_array_test_with_parse_type.bal
@@ -262,3 +262,118 @@ function testXSDChoiceArrayWithXmlValueXsdChoiceArrayWithXmlValueRecord6() retur
     test:assertEquals(v2, {choice_XSDChoiceArrayWithXmlValueXsdChoiceArrayWithXmlValueRecord6_1: {field1: [{value1: {a: ["1", "1"]}}, {value1: {a:["1", "1"]}}], field2: [{value2: {d: ["1", "1"]}}, {value2: {d: ["1", "1"]}}]}, choice_XSDChoiceArrayWithXmlValueXsdChoiceArrayWithXmlValueRecord6_2: {field4: [{value1: {a: ["1", "1"]}}, {value1: {a:["1", "1"]}}], field5: [{value2: {d: ["1", "1"]}}, {value2: {d: ["1","1"]}}]}});
     test:assertEquals(toXml(check v2), xml `<Root><field1><a>1</a><a>1</a></field1><field1><a>1</a><a>1</a></field1><field2><d>1</d><d>1</d></field2><field2><d>1</d><d>1</d></field2><field4><a>1</a><a>1</a></field4><field4><a>1</a><a>1</a></field4><field5><d>1</d><d>1</d></field5><field5><d>1</d><d>1</d></field5></Root>`);
 }
+
+@Name {
+    value: "Root"
+}
+type XsdChoiceArrayWithNestedSeqXmlValue record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 2
+    }
+    ChoiceArrNestedSeqItemXmlValue[] choice_arr_nested_seq;
+|};
+
+type ChoiceArrNestedSeqItemXmlValue record {|
+    @Sequence {
+        minOccurs: 0,
+        maxOccurs: 1
+    }
+    SeqInsideChoiceArrXmlValue seq_in_arr?;
+    string direct?;
+|};
+
+type SeqInsideChoiceArrXmlValue record {|
+    @SequenceOrder {value: 1}
+    string p;
+
+    @SequenceOrder {value: 2}
+    string q;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceArrayWithNestedSeqXmlValue() returns error? {
+    xml xmlValue;
+    XsdChoiceArrayWithNestedSeqXmlValue|Error v;
+
+    xmlValue = xml `<Root><p>hello</p><q>world</q></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_seq: [{seq_in_arr: {p: "hello", q: "world"}}]});
+
+    xmlValue = xml `<Root><direct>test</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_seq: [{direct: "test"}]});
+
+    xmlValue = xml `<Root><p>hello</p><q>world</q><direct>test</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_seq: [{seq_in_arr: {p: "hello", q: "world"}}, {direct: "test"}]});
+
+    xmlValue = xml `<Root><p>hello</p><q>world</q><direct>test</direct><p>foo</p><q>bar</q></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_arr_nested_seq' occurs more than the max allowed times");
+
+    xmlValue = xml `<Root></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_arr_nested_seq' occurs less than the min required times");
+}
+
+@Name {
+    value: "Root"
+}
+type XsdChoiceArrayWithNestedChoiceXmlValue record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 2
+    }
+    ChoiceArrNestedChoiceItemXmlValue[] choice_arr_nested_ch;
+|};
+
+type ChoiceArrNestedChoiceItemXmlValue record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceInArrXmlValue inner_ch?;
+    string direct?;
+|};
+
+type InnerChoiceInArrXmlValue record {|
+    string x?;
+    string y?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceArrayWithNestedChoiceXmlValue() returns error? {
+    xml xmlValue;
+    XsdChoiceArrayWithNestedChoiceXmlValue|Error v;
+
+    xmlValue = xml `<Root><x>foo</x></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_ch: [{inner_ch: {x: "foo"}}]});
+
+    xmlValue = xml `<Root><direct>test</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_ch: [{direct: "test"}]});
+
+    xmlValue = xml `<Root><x>foo</x><direct>test</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_nested_ch: [{inner_ch: {x: "foo"}}, {direct: "test"}]});
+
+    xmlValue = xml `<Root><x>foo</x><direct>test</direct><y>bar</y></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_arr_nested_ch' occurs more than the max allowed times");
+
+    xmlValue = xml `<Root></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_arr_nested_ch' occurs less than the min required times");
+}

--- a/ballerina/tests/xsd_choice_test.bal
+++ b/ballerina/tests/xsd_choice_test.bal
@@ -849,3 +849,170 @@ function testXsdChoiceWithMixedNestedGroups() returns error? {
     test:assertTrue(v is Error);
     test:assertEquals((<Error>v).message(), "'choice_alt' occurs more than the max allowed times");
 }
+
+type XSDChoiceComplexElementRecord record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 2
+    }
+    ChoiceComplexAndSimple choice_complex?;
+|};
+
+type ChoiceComplexAndSimple record {|
+    ComplexChoiceElem complex_elem?;
+    string b?;
+|};
+
+type ComplexChoiceElem record {|
+    string b?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceIsMiddleOfElement() returns error? {
+    string xmlStr = string `<Root><complex_elem><b>hello</b></complex_elem></Root>`;
+    XSDChoiceComplexElementRecord|Error v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_complex: {complex_elem: {b: "hello"}}});
+}
+
+type XSDChoiceWithArraySeqRecord record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceContainingArraySeq choice_arr_seq?;
+|};
+
+type ChoiceContainingArraySeq record {|
+    @Sequence {
+        minOccurs: 0,
+        maxOccurs: 3
+    }
+    ArraySeqElem[] arr_seq?;
+    string direct?;
+|};
+
+type ArraySeqElem record {|
+    @SequenceOrder {value: 1}
+    string x;
+
+    @SequenceOrder {value: 2}
+    string y;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceWithArrayNestedSeq() returns error? {
+    string xmlStr;
+    XSDChoiceWithArraySeqRecord|Error v;
+    xmlStr = string `<Root><x>val1</x><y>val2</y></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_seq: {arr_seq: [{x: "val1", y: "val2"}]}});
+
+    xmlStr = string `<Root><direct>hello</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_arr_seq: {direct: "hello"}});
+}
+
+type XSDChoiceWithDeepNestedSeqRecord record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceWithTwoLevelSeq choice_two_lvl?;
+|};
+
+type ChoiceWithTwoLevelSeq record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    TwoLevelOuterSeq two_level_seq?;
+    string direct?;
+|};
+
+type TwoLevelOuterSeq record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    TwoLevelInnerSeq inner_seq;
+|};
+
+type TwoLevelInnerSeq record {|
+    @SequenceOrder {value: 1}
+    string x;
+
+    @SequenceOrder {value: 2}
+    string y;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceWithDeepNestedSeq() returns error? {
+    string xmlStr;
+    XSDChoiceWithDeepNestedSeqRecord|Error v;
+
+    xmlStr = string `<Root><first>hello</first><x>one</x><y>two</y></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_two_lvl: {two_level_seq: {first: "hello", inner_seq: {x: "one", y: "two"}}}});
+
+    xmlStr = string `<Root><direct>test</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_two_lvl: {direct: "test"}});
+}
+
+type XSDChoiceWithSeqInnerChoiceRecord record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceWithSeqContainingChoice choice_seq_ch?;
+|};
+
+type ChoiceWithSeqContainingChoice record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithInnerChoiceRec seq_inner_ch?;
+    string direct?;
+|};
+
+type SeqWithInnerChoiceRec record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Choice {minOccurs: 1, maxOccurs: 1}
+    InnerChoiceInSeq inner_ch;
+|};
+
+type InnerChoiceInSeq record {|
+    string p?;
+    string q?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceWithSeqContainingInnerChoice() returns error? {
+    string xmlStr;
+    XSDChoiceWithSeqInnerChoiceRecord|Error v;
+
+    xmlStr = string `<Root><first>hello</first><p>foo</p></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_seq_ch: {seq_inner_ch: {first: "hello", inner_ch: {p: "foo"}}}});
+
+    xmlStr = string `<Root><first>hello</first><q>bar</q></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_seq_ch: {seq_inner_ch: {first: "hello", inner_ch: {q: "bar"}}}});
+
+    xmlStr = string `<Root><direct>test</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_seq_ch: {direct: "test"}});
+}

--- a/ballerina/tests/xsd_choice_test.bal
+++ b/ballerina/tests/xsd_choice_test.bal
@@ -644,3 +644,208 @@ function testXsdChoice10() returns error? {
     test:assertTrue(v2 is Error);
     test:assertEquals((<Error>v2).message(), "'value2' occurs more than the max allowed times");
 }
+
+type XSDChoiceRecordNestedChoice record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    OuterChoiceNested outer_choice?;
+|};
+
+type OuterChoiceNested record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceNested1 inner_choice1?;
+
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceNested2 inner_choice2?;
+
+    int direct?;
+|};
+
+type InnerChoiceNested1 record {|
+    string a?;
+    string b?;
+|};
+
+type InnerChoiceNested2 record {|
+    int x?;
+    int y?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdNestedChoiceGroups() returns error? {
+    string xmlStr;
+    XSDChoiceRecordNestedChoice|Error v;
+
+    xmlStr = string `<Root><a>hello</a></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {inner_choice1: {a: "hello"}}});
+
+    xmlStr = string `<Root><b>world</b></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {inner_choice1: {b: "world"}}});
+
+    xmlStr = string `<Root><x>1</x></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {inner_choice2: {x: 1}}});
+
+    xmlStr = string `<Root><y>2</y></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {inner_choice2: {y: 2}}});
+
+    xmlStr = string `<Root><direct>5</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {direct: 5}});
+
+    xmlStr = string `<Root><a>hello</a><x>1</x></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'outer_choice' occurs more than the max allowed times");
+
+    xmlStr = string `<Root><a>hello</a><b>world</b></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'inner_choice1' occurs more than the max allowed times");
+
+    xmlStr = string `<Root></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'outer_choice' occurs less than the min required times");
+}
+
+type XSDChoiceWithNestedSeqRecord record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceWithNestedSeq choice_with_seq?;
+|};
+
+type ChoiceWithNestedSeq record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqInChoice seq_in_choice?;
+
+    int direct?;
+|};
+
+type SeqInChoice record {|
+    @SequenceOrder {value: 1}
+    string m;
+
+    @SequenceOrder {value: 2}
+    string n;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceWithNestedSequence() returns error? {
+    string xmlStr;
+    XSDChoiceWithNestedSeqRecord|Error v;
+
+    xmlStr = string `<Root><m>hello</m><n>world</n></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_seq: {seq_in_choice: {m: "hello", n: "world"}}});
+
+    xmlStr = string `<Root><direct>1</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_seq: {direct: 1}});
+
+    xmlStr = string `<Root><m>hello</m><n>world</n><direct>1</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_with_seq' occurs more than the max allowed times");
+
+    xmlStr = string `<Root></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_with_seq' occurs less than the min required times");
+}
+
+type XSDChoiceWithMixedNestedRecord record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceWithMixedNested choice_with_mixed;
+|};
+
+type ChoiceWithMixedNested record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    MixedSeqAlt seq_alt?;
+
+    @Choice {
+        minOccurs: 0,
+        maxOccurs: 1
+    }
+    MixedChoiceAlt choice_alt?;
+
+    int direct?;
+|};
+
+type MixedSeqAlt record {|
+    @SequenceOrder {value: 1}
+    string s1;
+
+    @SequenceOrder {value: 2}
+    string s2;
+|};
+
+type MixedChoiceAlt record {|
+    string c1?;
+    string c2?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceWithMixedNestedGroups() returns error? {
+    string xmlStr;
+    XSDChoiceWithMixedNestedRecord|Error v;
+
+    xmlStr = string `<Root><s1>hello</s1><s2>world</s2></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_mixed: {seq_alt: {s1: "hello", s2: "world"}}});
+
+    xmlStr = string `<Root><c1>hello</c1></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_mixed: {choice_alt: {c1: "hello"}}});
+
+    xmlStr = string `<Root><c2>world</c2></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_mixed: {choice_alt: {c2: "world"}}});
+
+    xmlStr = string `<Root><direct>1</direct></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_mixed: {direct: 1}});
+
+    xmlStr = string `<Root><s1>hello</s1><s2>world</s2><c1>test</c1></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_with_mixed' occurs more than the max allowed times");
+
+    xmlStr = string `<Root><c1>hello</c1><c2>world</c2></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_alt' occurs more than the max allowed times");
+}

--- a/ballerina/tests/xsd_choice_test_with_parse_type.bal
+++ b/ballerina/tests/xsd_choice_test_with_parse_type.bal
@@ -519,15 +519,17 @@ function testXsdChoiceWithXmlValue8() returns error? {
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
     string response = (<Error>v2).message();
-    test:assertTrue(response == "required field 'num' not present in XML" 
-        || response == "required field 'num2' not present in XML");
+    test:assertTrue(response == "required field 'num' not present in XML"
+        || response == "required field 'num2' not present in XML"
+        || response == "required field 'choice_XSDChoiceWithXmlValueRecord8_2' not present in XML");
 
     xmlValue = xml `<Root><test><status><value1>Success</value1><value2>Fail</value2></status></test><a>2</a></Root>`;
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
     response = (<Error>v2).message();
-    test:assertTrue(response == "required field 'num' not present in XML" 
-        || response == "required field 'num2' not present in XML");
+    test:assertTrue(response == "required field 'num' not present in XML"
+        || response == "required field 'num2' not present in XML"
+        || response == "required field 'choice_XSDChoiceWithXmlValueRecord8_1' not present in XML");
 }
 
 @Name {

--- a/ballerina/tests/xsd_choice_test_with_parse_type.bal
+++ b/ballerina/tests/xsd_choice_test_with_parse_type.bal
@@ -640,3 +640,127 @@ function testXsdChoiceWithXmlValue10() returns error? {
     test:assertTrue(toXmlResult is Error);
     test:assertEquals((<Error>toXmlResult).message(), "'value2' occurs more than the max allowed times");
 }
+
+@Name {value: "Root"}
+type XSDChoiceNestedChoiceXmlValue record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    OuterChoiceNestedXmlValue outer_choice;
+|};
+
+type OuterChoiceNestedXmlValue record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceNestedXmlValue1 inner_choice1?;
+
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceNestedXmlValue2 inner_choice2?;
+
+    int direct?;
+|};
+
+type InnerChoiceNestedXmlValue1 record {|
+    string a?;
+    string b?;
+|};
+
+type InnerChoiceNestedXmlValue2 record {|
+    int x?;
+    int y?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdNestedChoiceGroupsWithXmlValue() returns error? {
+    xml xmlValue;
+    XSDChoiceNestedChoiceXmlValue|Error v;
+
+    xmlValue = xml `<Root><a>hello</a></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {inner_choice1: {a: "hello"}}});
+    Error? e = validate(xmlValue, XSDChoiceNestedChoiceXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><x>1</x></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {inner_choice2: {x: 1}}});
+    e = validate(xmlValue, XSDChoiceNestedChoiceXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><direct>5</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outer_choice: {direct: 5}});
+    e = validate(xmlValue, XSDChoiceNestedChoiceXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><a>hello</a><x>1</x></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'outer_choice' occurs more than the max allowed times");
+    e = validate(xmlValue, XSDChoiceNestedChoiceXmlValue);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: ''outer_choice' occurs more than the max allowed times'");
+}
+
+@Name {value: "Root"}
+type XSDChoiceWithNestedSeqXmlValue record {|
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceWithNestedSeqXmlValue choice_with_seq;
+|};
+
+type ChoiceWithNestedSeqXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqInChoiceXmlValue seq_in_choice?;
+
+    int direct?;
+|};
+
+type SeqInChoiceXmlValue record {|
+    @SequenceOrder {value: 1}
+    string m;
+
+    @SequenceOrder {value: 2}
+    string n;
+|};
+
+@test:Config {groups: ["xsd", "xsd_choice"]}
+function testXsdChoiceWithNestedSequenceXmlValue() returns error? {
+    xml xmlValue;
+    XSDChoiceWithNestedSeqXmlValue|Error v;
+
+    xmlValue = xml `<Root><m>hello</m><n>world</n></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_seq: {seq_in_choice: {m: "hello", n: "world"}}});
+    Error? e = validate(xmlValue, XSDChoiceWithNestedSeqXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><direct>1</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {choice_with_seq: {direct: 1}});
+    e = validate(xmlValue, XSDChoiceWithNestedSeqXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><m>hello</m><n>world</n><direct>1</direct></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_with_seq' occurs more than the max allowed times");
+    e = validate(xmlValue, XSDChoiceWithNestedSeqXmlValue);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: ''choice_with_seq' occurs more than the max allowed times'");
+}
+

--- a/ballerina/tests/xsd_choice_test_with_parse_type.bal
+++ b/ballerina/tests/xsd_choice_test_with_parse_type.bal
@@ -518,12 +518,16 @@ function testXsdChoiceWithXmlValue8() returns error? {
     xmlValue = xml `<Root><test><age>10</age></test><a>2</a></Root>`;
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
-    test:assertEquals((<Error>v2).message(), "required field 'num' not present in XML");
+    string response = (<Error>v2).message();
+    test:assertTrue(response == "required field 'num' not present in XML" 
+        || response == "required field 'num2' not present in XML");
 
     xmlValue = xml `<Root><test><status><value1>Success</value1><value2>Fail</value2></status></test><a>2</a></Root>`;
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
-    test:assertEquals((<Error>v2).message(), "required field 'num' not present in XML");
+    response = (<Error>v2).message();
+    test:assertTrue(response == "required field 'num' not present in XML" 
+        || response == "required field 'num2' not present in XML");
 }
 
 @Name {

--- a/ballerina/tests/xsd_choice_test_with_parse_type.bal
+++ b/ballerina/tests/xsd_choice_test_with_parse_type.bal
@@ -518,12 +518,12 @@ function testXsdChoiceWithXmlValue8() returns error? {
     xmlValue = xml `<Root><test><age>10</age></test><a>2</a></Root>`;
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
-    test:assertEquals((<Error>v2).message(), "'choice_XSDChoiceWithXmlValueRecord8_2' occurs less than the min required times");
+    test:assertEquals((<Error>v2).message(), "required field 'num' not present in XML");
 
     xmlValue = xml `<Root><test><status><value1>Success</value1><value2>Fail</value2></status></test><a>2</a></Root>`;
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
-    test:assertEquals((<Error>v2).message(), "'choice_XSDChoiceWithXmlValueRecord8_1' occurs less than the min required times");
+    test:assertEquals((<Error>v2).message(), "required field 'num' not present in XML");
 }
 
 @Name {

--- a/ballerina/tests/xsd_sequence_test_with_element_annotation_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_test_with_element_annotation_with_parse_type.bal
@@ -387,8 +387,6 @@ function testXsdSequenceWithElementAnnotationWithXmlValue3() returns error? {
     test:assertEquals((<Error>toXmlResult).message(), "'b' occurs more than the max allowed times");
 }
 
-// Test for nested sequences (sequence within a sequence)
-// Models the XSD pattern where an xs:sequence contains another xs:sequence as a group
 @Name {
     value: "Root"
 }
@@ -434,25 +432,21 @@ function testXsdNestedSequence() returns error? {
     xml xmlValue;
     XsdNestedSequence|Error v;
 
-    // Basic nested sequence: outer has optional itemA and inner sequence with itemB[] + itemC
     xmlValue = xml `<Root><itemB><val>b1</val></itemB><itemC><val>c1</val></itemC></Root>`;
     v = parseAsType(xmlValue);
     test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
     test:assertEquals(v, {nestedSeqOuter: {nestedSeqInner: {itemB: [{val: "b1"}], itemC: {val: "c1"}}}});
 
-    // With optional itemA present
     xmlValue = xml `<Root><itemA><name>a1</name></itemA><itemB><val>b1</val></itemB><itemC><val>c1</val></itemC></Root>`;
     v = parseAsType(xmlValue);
     test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
     test:assertEquals(v, {nestedSeqOuter: {itemA: {name: "a1"}, nestedSeqInner: {itemB: [{val: "b1"}], itemC: {val: "c1"}}}});
 
-    // Multiple itemB elements (array)
     xmlValue = xml `<Root><itemB><val>b1</val></itemB><itemB><val>b2</val></itemB><itemC><val>c1</val></itemC></Root>`;
     v = parseAsType(xmlValue);
     test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
     test:assertEquals(v, {nestedSeqOuter: {nestedSeqInner: {itemB: [{val: "b1"}, {val: "b2"}], itemC: {val: "c1"}}}});
 
-    // Missing required itemC should fail
     xmlValue = xml `<Root><itemB><val>b1</val></itemB></Root>`;
     v = parseAsType(xmlValue);
     test:assertTrue(v is Error);

--- a/ballerina/tests/xsd_sequence_test_with_element_annotation_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_test_with_element_annotation_with_parse_type.bal
@@ -371,7 +371,7 @@ function testXsdSequenceWithElementAnnotationWithXmlValue3() returns error? {
     xmlValue = xml `<Root><field1><b>2</b><c>3</c></field1><field1><a>1</a><b>2</b><c>3</c></field1><field3><g>1</g><h>2</h><i>3</i></field3><field4><a>1</a><a>2</a><a>3</a><b>2</b><c>3</c></field4><field5><d>1</d><e>2</e><f>3</f></field5><field6><g>1</g><h>2</h></field6></Root>`;
     v2 = parseAsType(xmlValue);
     test:assertTrue(v2 is Error);
-    test:assertEquals((<Error>v2).message(), "required field 'i' not present in XML");
+    test:assertEquals((<Error>v2).message(), "Element(s) 'i' is not found in 'value3'");
 
     xmlValue = xml `<Root><field1><a>1</a><b>2</b><c>3</c></field1><field1><a>1</a><b>2</b><c>3</c></field1><field2><d>1</d><e>2</e><f>3</f></field2><field2><d>1</d><e>2</e><f>3</f></field2><field2><d>1</d><e>2</e><f>3</f></field2><field3><g>1</g><h>2</h><i>3</i></field3><field4><a>1</a><b>2</b><c>3</c></field4><field5><d>1</d><e>2</e><f>3</f></field5><field5><d>1</d><e>2</e><f>3</f></field5><field5><d>1</d><e>2</e><f>3</f></field5><field5><d>1</d><e>2</e><f>3</f></field5><field6><g>1</g><h>2</h><i>3</i></field6></Root>`;
     v2 = parseAsType(xmlValue);
@@ -385,4 +385,75 @@ function testXsdSequenceWithElementAnnotationWithXmlValue3() returns error? {
     xml|Error toXmlResult = toXml(<XsdSequenceWithElementAnnotationWithXmlValue3>{seq_XsdSequenceWithElementAnnotationWithXmlValue3_1: {field1: [{value1: {a: ["1"], b: ["2"], c: "3"}}, {value1: {a: ["1"], b: ["2", "2", "2", "2", "2"], c: "3"}}], field2: [{value2: {d: "1", e: "2", f: "3"}}, {value2: {d: "1", e: "2", f: "3"}}, {value2: {d: "1", e: "2", f: "3"}}], field3: {value3: {g: "1", h: "2", i: "3"}}}});
     test:assertTrue(toXmlResult is Error);
     test:assertEquals((<Error>toXmlResult).message(), "'b' occurs more than the max allowed times");
+}
+
+// Test for nested sequences (sequence within a sequence)
+// Models the XSD pattern where an xs:sequence contains another xs:sequence as a group
+@Name {
+    value: "Root"
+}
+type XsdNestedSequence record {|
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    NestedSeqOuter nestedSeqOuter;
+|};
+
+type NestedSeqOuter record {|
+    @SequenceOrder {value: 1}
+    @Element {minOccurs: 0, maxOccurs: 1}
+    NestedSeqItemA itemA?;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    NestedSeqInner nestedSeqInner;
+|};
+
+type NestedSeqInner record {|
+    @SequenceOrder {value: 1}
+    @Element {minOccurs: 1, maxOccurs: 3}
+    NestedSeqItemB[] itemB;
+
+    @SequenceOrder {value: 2}
+    @Element {minOccurs: 1, maxOccurs: 1}
+    NestedSeqItemC itemC;
+|};
+
+type NestedSeqItemA record {|
+    string name;
+|};
+
+type NestedSeqItemB record {|
+    string val;
+|};
+
+type NestedSeqItemC record {|
+    string val;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence", "xsd_nested_sequence"]}
+function testXsdNestedSequence() returns error? {
+    xml xmlValue;
+    XsdNestedSequence|Error v;
+
+    // Basic nested sequence: outer has optional itemA and inner sequence with itemB[] + itemC
+    xmlValue = xml `<Root><itemB><val>b1</val></itemB><itemC><val>c1</val></itemC></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {nestedSeqOuter: {nestedSeqInner: {itemB: [{val: "b1"}], itemC: {val: "c1"}}}});
+
+    // With optional itemA present
+    xmlValue = xml `<Root><itemA><name>a1</name></itemA><itemB><val>b1</val></itemB><itemC><val>c1</val></itemC></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {nestedSeqOuter: {itemA: {name: "a1"}, nestedSeqInner: {itemB: [{val: "b1"}], itemC: {val: "c1"}}}});
+
+    // Multiple itemB elements (array)
+    xmlValue = xml `<Root><itemB><val>b1</val></itemB><itemB><val>b2</val></itemB><itemC><val>c1</val></itemC></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {nestedSeqOuter: {nestedSeqInner: {itemB: [{val: "b1"}, {val: "b2"}], itemC: {val: "c1"}}}});
+
+    // Missing required itemC should fail
+    xmlValue = xml `<Root><itemB><val>b1</val></itemB></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
 }

--- a/ballerina/tests/xsd_sequence_tests.bal
+++ b/ballerina/tests/xsd_sequence_tests.bal
@@ -1525,3 +1525,95 @@ function testXsdSeqWithMixedNestedGroups() returns error? {
     test:assertTrue(v is Error);
     test:assertEquals((<Error>v).message(), "Element(s) 'nested_seq' is not found in 'seq_mixed'");
 }
+
+type AliasedInnerSeqRec record {|
+    @SequenceOrder {value: 1}
+    string a;
+
+    @SequenceOrder {value: 2}
+    string b;
+|};
+
+type AliasedInnerSeq AliasedInnerSeqRec;
+
+type SeqWithTypeAliasFields record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    AliasedInnerSeq nested_seq;
+
+    @SequenceOrder {value: 3}
+    string last;
+|};
+
+type XSDSeqWithTypeAliasRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithTypeAliasFields seq_type_alias?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithTypeAliasedNestedSeq() returns error? {
+    string xmlStr;
+    XSDSeqWithTypeAliasRecord|Error v;
+
+    xmlStr = string `<Root><first>start</first><a>x</a><b>y</b><last>end</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_type_alias: {first: "start", nested_seq: {a: "x", b: "y"}, last: "end"}});
+
+    xmlStr = string `<Root><first>start</first><last>end</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'nested_seq' is not found in 'seq_type_alias'");
+
+    xmlStr = string `<Root><a>x</a><b>y</b><last>end</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'first' is not found in 'seq_type_alias'");
+}
+
+type IntList int[];
+
+type SeqWithAliasedArrayFields record {|
+    @SequenceOrder {value: 1}
+    IntList nums;
+
+    @SequenceOrder {value: 2}
+    string label;
+|};
+
+type XSDSeqWithAliasedArrayRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithAliasedArrayFields seq_arr?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithTypeAliasedArrayField() returns error? {
+    string xmlStr;
+    XSDSeqWithAliasedArrayRecord|Error v;
+
+    xmlStr = string `<Root><nums>1</nums><nums>2</nums><nums>3</nums><label>done</label></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_arr: {nums: [1, 2, 3], label: "done"}});
+
+    xmlStr = string `<Root><nums>5</nums><label>single</label></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_arr: {nums: [5], label: "single"}});
+
+    xmlStr = string `<Root><label>missing-nums</label></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+}

--- a/ballerina/tests/xsd_sequence_tests.bal
+++ b/ballerina/tests/xsd_sequence_tests.bal
@@ -1216,3 +1216,137 @@ function testXsdNestedSequenceWithArrayInnerField() returns error? {
     test:assertTrue(value is Error);
 }
 
+type XSDThreeLevelNestedSeq record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    Level1Seq level1Seq;
+|};
+
+type Level1Seq record {|
+    @SequenceOrder {value: 1}
+    string level1Field;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    Level2Seq level2Seq;
+|};
+
+type Level2Seq record {|
+    @SequenceOrder {value: 1}
+    string level2Field;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    Level3Seq level3Seq;
+|};
+
+type Level3Seq record {|
+    @SequenceOrder {value: 1}
+    string level3Field;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdThreeLevelNestedSeq() returns error? {
+    string xmlStr;
+    XSDThreeLevelNestedSeq|Error v;
+
+    xmlStr = string `<Root><level1Field>a</level1Field><level2Field>b</level2Field><level3Field>c</level3Field></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {level1Seq: {level1Field: "a", level2Seq: {level2Field: "b", level3Seq: {level3Field: "c"}}}});
+
+    xmlStr = string `<Root><level2Field>b</level2Field><level1Field>a</level1Field><level3Field>c</level3Field></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+
+    xmlStr = string `<Root><level1Field>a</level1Field><level2Field>b</level2Field></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+}
+
+type XSDSeqWithArrayNestedSeq record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithArrayNested seqMain;
+|};
+
+type SeqWithArrayNested record {|
+    @SequenceOrder {value: 1}
+    string before;
+
+    @Sequence {minOccurs: 1, maxOccurs: 3}
+    @SequenceOrder {value: 2}
+    ArrayNestedSeq[] nestedArr;
+
+    @SequenceOrder {value: 3}
+    string after;
+|};
+
+type ArrayNestedSeq record {|
+    @SequenceOrder {value: 1}
+    string x;
+
+    @SequenceOrder {value: 2}
+    string y;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithArrayNestedSeq() returns error? {
+    string xmlStr;
+    XSDSeqWithArrayNestedSeq|Error v;
+
+    xmlStr = string `<Root><before>start</before><x>a1</x><y>b1</y><x>a2</x><y>b2</y><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seqMain: {before: "start", nestedArr: [{x: "a1", y: "b1"}, {x: "a2", y: "b2"}], after: "end"}});
+
+    xmlStr = string `<Root><x>a1</x><y>b1</y><before>start</before><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+
+    xmlStr = string `<Root><before>start</before><x>a1</x><y>b1</y></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+}
+
+type XSDSeqWithNameAnnotationDirect record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqNameDirect seqNameDirect;
+|};
+
+type SeqNameDirect record {|
+    @Name {value: "first-name"}
+    @SequenceOrder {value: 1}
+    string firstName;
+
+    @Name {value: "last-name"}
+    @SequenceOrder {value: 2}
+    string lastName;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithNameAnnotationDirect() returns error? {
+    string xmlStr;
+    XSDSeqWithNameAnnotationDirect|Error v;
+
+    xmlStr = string `<Root><first-name>John</first-name><last-name>Doe</last-name></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seqNameDirect: {firstName: "John", lastName: "Doe"}});
+
+    xmlStr = string `<Root><last-name>Doe</last-name><first-name>John</first-name></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+
+    xmlStr = string `<Root><first-name>John</first-name></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+}
+

--- a/ballerina/tests/xsd_sequence_tests.bal
+++ b/ballerina/tests/xsd_sequence_tests.bal
@@ -1394,3 +1394,134 @@ function testXsdSeqWithNameAnnotationDirect() returns error? {
     test:assertTrue(v is Error);
 }
 
+type XSDSeqWithNestedChoiceRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithNestedChoice seq_with_choice;
+|};
+
+type SeqWithNestedChoice record {|
+    @SequenceOrder {value: 1}
+    string before;
+
+    @SequenceOrder {value: 2}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceInSeq choice_in_seq;
+
+    @SequenceOrder {value: 3}
+    string after;
+|};
+
+type ChoiceInSeq record {|
+    int p?;
+    string q?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithNestedChoice() returns error? {
+    string xmlStr;
+    XSDSeqWithNestedChoiceRecord|Error v;
+
+    xmlStr = string `<Root><before>start</before><p>1</p><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_with_choice: {before: "start", choice_in_seq: {p: 1}, after: "end"}});
+
+    xmlStr = string `<Root><before>start</before><q>hello</q><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_with_choice: {before: "start", choice_in_seq: {q: "hello"}, after: "end"}});
+
+    xmlStr = string `<Root><before>start</before><p>1</p><q>hello</q><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_in_seq' occurs more than the max allowed times");
+
+    xmlStr = string `<Root><before>start</before><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'choice_in_seq' is not found in 'seq_with_choice'");
+
+    xmlStr = string `<Root><p>1</p><after>end</after></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'before' is not found in 'seq_with_choice'");
+}
+
+type XSDSeqWithMixedNestedRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithMixedNested seq_mixed;
+|};
+
+type SeqWithMixedNested record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    MixedNestedSeq nested_seq;
+
+    @SequenceOrder {value: 3}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    MixedNestedChoice nested_choice;
+
+    @SequenceOrder {value: 4}
+    string last;
+|};
+
+type MixedNestedSeq record {|
+    @SequenceOrder {value: 1}
+    string ns1;
+
+    @SequenceOrder {value: 2}
+    string ns2;
+|};
+
+type MixedNestedChoice record {|
+    int nc1?;
+    string nc2?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithMixedNestedGroups() returns error? {
+    string xmlStr;
+    XSDSeqWithMixedNestedRecord|Error v;
+
+    xmlStr = string `<Root><first>a</first><ns1>b</ns1><ns2>c</ns2><nc1>1</nc1><last>d</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_mixed: {first: "a", nested_seq: {ns1: "b", ns2: "c"}, nested_choice: {nc1: 1}, last: "d"}});
+
+    xmlStr = string `<Root><first>a</first><ns1>b</ns1><ns2>c</ns2><nc2>hello</nc2><last>d</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_mixed: {first: "a", nested_seq: {ns1: "b", ns2: "c"}, nested_choice: {nc2: "hello"}, last: "d"}});
+
+    xmlStr = string `<Root><first>a</first><ns1>b</ns1><nc1>1</nc1><last>d</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+
+    xmlStr = string `<Root><first>a</first><ns1>b</ns1><ns2>c</ns2><last>d</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'nested_choice' is not found in 'seq_mixed'");
+
+    xmlStr = string `<Root><first>a</first><nc1>1</nc1><ns1>b</ns1><ns2>c</ns2><last>d</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'nested_seq' is not found in 'seq_mixed'");
+}

--- a/ballerina/tests/xsd_sequence_tests.bal
+++ b/ballerina/tests/xsd_sequence_tests.bal
@@ -1313,6 +1313,50 @@ function testXsdSeqWithArrayNestedSeq() returns error? {
     test:assertTrue(v is Error);
 }
 
+type XSDSeqWithSharedElementName record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithSharedName seqMain;
+|};
+
+type SeqWithSharedName record {|
+    @SequenceOrder {value: 1}
+    string id;
+
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    @SequenceOrder {value: 2}
+    SharedNameNested nested;
+|};
+
+type SharedNameNested record {|
+    @SequenceOrder {value: 1}
+    string name;
+
+    @SequenceOrder {value: 2}
+    string id;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithSharedElementName() returns error? {
+    string xmlStr;
+    XSDSeqWithSharedElementName|Error v;
+
+    xmlStr = string `<Root><id>parent-id</id><name>some-name</name><id>nested-id</id></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seqMain: {id: "parent-id", nested: {name: "some-name", id: "nested-id"}}});
+
+    xmlStr = string `<Root><name>some-name</name><id>nested-id</id><id>parent-id</id></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+
+    xmlStr = string `<Root><id>parent-id</id><name>some-name</name></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+}
+
 type XSDSeqWithNameAnnotationDirect record {|
     @Sequence {
         minOccurs: 1,

--- a/ballerina/tests/xsd_sequence_tests.bal
+++ b/ballerina/tests/xsd_sequence_tests.bal
@@ -1140,3 +1140,79 @@ function testXsdSequenceWithRecordArrayField() returns error? {
     test:assertEquals((<Error>value).message(), "Element 'status' is not in the correct order in 'seq'");
 }
 
+type XSDSequenceRecordWithUnboundedArray record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    Seq_XSDSequenceRecordWithUnboundedArray seq;
+|};
+
+type Seq_XSDSequenceRecordWithUnboundedArray record {|
+    @SequenceOrder {value: 1}
+    string[] tags;
+    @SequenceOrder {value: 2}
+    string label;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSequenceWithUnboundedArrayField() returns error? {
+    string xmlStr = string `<Root><tags>a</tags><label>end</label></Root>`;
+    XSDSequenceRecordWithUnboundedArray|Error value = parseString(xmlStr);
+    test:assertEquals(value, {seq: {tags: ["a"], label: "end"}});
+
+    xmlStr = string `<Root><tags>a</tags><tags>b</tags><tags>c</tags><tags>d</tags><tags>e</tags><label>end</label></Root>`;
+    value = parseString(xmlStr);
+    test:assertEquals(value, {seq: {tags: ["a", "b", "c", "d", "e"], label: "end"}});
+
+    xmlStr = string `<Root><label>end</label><tags>a</tags></Root>`;
+    value = parseString(xmlStr);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "Element 'label' is not in the correct order in 'seq'");
+
+    xmlStr = string `<Root><tags>a</tags></Root>`;
+    value = parseString(xmlStr);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "Element(s) 'label' is not found in 'seq'");
+}
+
+type XSDNestedSequenceWithArrayInner record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    OuterArraySeq outerSeq;
+|};
+
+type OuterArraySeq record {|
+    @SequenceOrder {value: 1}
+    string header;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    OuterArraySeqInner innerSeq;
+|};
+
+type OuterArraySeqInner record {|
+    @SequenceOrder {value: 1}
+    string item;
+    @SequenceOrder {value: 2}
+    int count;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdNestedSequenceWithArrayInnerField() returns error? {
+    string xmlStr = string `<Root><header>h1</header><item>x</item><count>3</count></Root>`;
+    XSDNestedSequenceWithArrayInner|Error value = parseString(xmlStr);
+    test:assertFalse(value is Error, (value is Error) ? (<Error>value).message() : "");
+    test:assertEquals(value, {outerSeq: {header: "h1", innerSeq: {item: "x", count: 3}}});
+
+    xmlStr = string `<Root><item>x</item><count>3</count><header>h1</header></Root>`;
+    value = parseString(xmlStr);
+    test:assertTrue(value is Error);
+
+    xmlStr = string `<Root><header>h1</header><count>3</count></Root>`;
+    value = parseString(xmlStr);
+    test:assertTrue(value is Error);
+}
+

--- a/ballerina/tests/xsd_sequence_tests.bal
+++ b/ballerina/tests/xsd_sequence_tests.bal
@@ -1617,3 +1617,290 @@ function testXsdSeqWithTypeAliasedArrayField() returns error? {
     v = parseString(xmlStr);
     test:assertTrue(v is Error);
 }
+
+type SeqRepeatTopItem record {|
+    @SequenceOrder {value: 1}
+    string p;
+
+    @SequenceOrder {value: 2}
+    string q;
+|};
+
+type XSDSeqTopLevelRepeatRecord record {|
+    @Sequence {
+        minOccurs: 2,
+        maxOccurs: 3
+    }
+    SeqRepeatTopItem[] items;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqTopLevelRepeat() returns error? {
+    string xmlStr;
+    XSDSeqTopLevelRepeatRecord|Error v;
+
+    xmlStr = string `<Root><p>a1</p><q>b1</q><p>a2</p><q>b2</q></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {items: [{p: "a1", q: "b1"}, {p: "a2", q: "b2"}]});
+
+    xmlStr = string `<Root><p>a1</p><q>b1</q><p>a2</p><q>b2</q><p>a3</p><q>b3</q></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {items: [{p: "a1", q: "b1"}, {p: "a2", q: "b2"}, {p: "a3", q: "b3"}]});
+
+    xmlStr = string `<Root><p>a1</p><q>b1</q></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+}
+
+type SeqThreeRequiredFields record {|
+    @SequenceOrder {value: 1}
+    string a;
+
+    @SequenceOrder {value: 2}
+    string b;
+
+    @SequenceOrder {value: 3}
+    string c;
+|};
+
+type XSDSeqMultipleMissingRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqThreeRequiredFields seq_three?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqMultipleMissingElements() returns error? {
+    string xmlStr;
+    XSDSeqMultipleMissingRecord|Error v;
+
+    xmlStr = string `<Root><a>val</a></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'b, c' is not found in 'seq_three'");
+
+    xmlStr = string `<Root><a>val</a><b>val2</b></Root>`;
+    v = parseString(xmlStr);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'c' is not found in 'seq_three'");
+}
+
+type ChoiceInsideSeqRecord record {|
+    string opt_x?;
+    string opt_y?;
+|};
+
+type SeqContainingChoiceField record {|
+    @SequenceOrder {value: 1}
+    string fixed_part;
+
+    @SequenceOrder {value: 2}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceInsideSeqRecord choice_part;
+|};
+
+type OuterSeqWithInnerSeqContainingChoice record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqContainingChoiceField inner_seq;
+
+    @SequenceOrder {value: 3}
+    string last;
+|};
+
+type XSDSeqWithChoiceInsideSeqRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    OuterSeqWithInnerSeqContainingChoice seq_ch?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithChoiceInsideNestedSeq() returns error? {
+    string xmlStr;
+    XSDSeqWithChoiceInsideSeqRecord|Error v;
+
+    xmlStr = string `<Root><first>start</first><fixed_part>mid</fixed_part><opt_x>xval</opt_x><last>end</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch: {first: "start", inner_seq: {fixed_part: "mid", choice_part: {opt_x: "xval"}}, last: "end"}});
+
+    xmlStr = string `<Root><first>start</first><fixed_part>mid</fixed_part><opt_y>yval</opt_y><last>end</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch: {first: "start", inner_seq: {fixed_part: "mid", choice_part: {opt_y: "yval"}}, last: "end"}});
+}
+
+type ArrayChoiceItem record {|
+    string item_a?;
+    string item_b?;
+|};
+
+type SeqWithArrayChoiceField record {|
+    @SequenceOrder {value: 1}
+    string header;
+
+    @SequenceOrder {value: 2}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 3
+    }
+    ArrayChoiceItem[] arr_choice;
+
+    @SequenceOrder {value: 3}
+    string footer;
+|};
+
+type XSDSeqWithArrayChoiceRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithArrayChoiceField seq_arr_ch?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithArrayChoiceField() returns error? {
+    string xmlStr;
+    XSDSeqWithArrayChoiceRecord|Error v;
+
+    xmlStr = string `<Root><header>h</header><item_a>a1</item_a><item_b>b1</item_b><footer>f</footer></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_arr_ch: {header: "h", arr_choice: [{item_a: "a1"}, {item_b: "b1"}], footer: "f"}});
+
+    xmlStr = string `<Root><header>h</header><item_a>only</item_a><footer>f</footer></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_arr_ch: {header: "h", arr_choice: [{item_a: "only"}], footer: "f"}});
+}
+
+type InnerSeqInChoiceRecord record {|
+    @SequenceOrder {value: 1}
+    string s1;
+
+    @SequenceOrder {value: 2}
+    string s2;
+|};
+
+type ChoiceContainingSeqField record {|
+    string direct_opt?;
+
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerSeqInChoiceRecord seq_in_ch?;
+|};
+
+type SeqWithChoiceContainingSeqField record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceContainingSeqField ch_inner;
+
+    @SequenceOrder {value: 3}
+    string last;
+|};
+
+type XSDSeqWithChoiceContainingSeqRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithChoiceContainingSeqField seq_ch_seq?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithChoiceContainingNestedSeq() returns error? {
+    string xmlStr;
+    XSDSeqWithChoiceContainingSeqRecord|Error v;
+
+    xmlStr = string `<Root><first>f</first><direct_opt>d</direct_opt><last>l</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch_seq: {first: "f", ch_inner: {direct_opt: "d"}, last: "l"}});
+
+    xmlStr = string `<Root><first>f</first><s1>v1</s1><s2>v2</s2><last>l</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch_seq: {first: "f", ch_inner: {seq_in_ch: {s1: "v1", s2: "v2"}}, last: "l"}});
+}
+
+type InnerChoiceInChoiceRecord record {|
+    string p?;
+    string q?;
+|};
+
+type ChoiceContainingChoiceField record {|
+    string direct_opt?;
+
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    InnerChoiceInChoiceRecord ch_in_ch?;
+|};
+
+type SeqWithChoiceContainingChoiceField record {|
+    @SequenceOrder {value: 1}
+    string first;
+
+    @SequenceOrder {value: 2}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceContainingChoiceField ch_outer;
+
+    @SequenceOrder {value: 3}
+    string last;
+|};
+
+type XSDSeqWithNestedChoiceInChoiceRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithChoiceContainingChoiceField seq_ch_ch?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithChoiceContainingNestedChoice() returns error? {
+    string xmlStr;
+    XSDSeqWithNestedChoiceInChoiceRecord|Error v;
+
+    xmlStr = string `<Root><first>f</first><direct_opt>d</direct_opt><last>l</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch_ch: {first: "f", ch_outer: {direct_opt: "d"}, last: "l"}});
+
+    xmlStr = string `<Root><first>f</first><p>pval</p><last>l</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch_ch: {first: "f", ch_outer: {ch_in_ch: {p: "pval"}}, last: "l"}});
+
+    xmlStr = string `<Root><first>f</first><q>qval</q><last>l</last></Root>`;
+    v = parseString(xmlStr);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_ch_ch: {first: "f", ch_outer: {ch_in_ch: {q: "qval"}}, last: "l"}});
+}

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1043,3 +1043,46 @@ function testXsdSequenceWithXmlValue13() returns error? {
     test:assertTrue(e is Error);
     test:assertEquals((<Error>e).message(), "Invalid XML found: 'Element 'field5' is not in the correct order in 'seq_XSDSequenceRecordWithXmlValue13_2''");
 }
+
+@Name {
+    value: "Root"
+}
+type XSDSequenceRecordWithArrayAndXmlValue record {|
+    @Sequence {
+        minOccurs: 0,
+        maxOccurs: 1
+    }
+    Seq_XSDSequenceRecordWithArrayAndXmlValue seq;
+|};
+
+type Seq_XSDSequenceRecordWithArrayAndXmlValue record {|
+    @SequenceOrder {value: 1}
+    string[] Source;
+    @SequenceOrder {value: 2}
+    string Dest;
+|};
+
+@test:Config {
+    groups: ["xsd", "xsd_sequence"]
+}
+function testXsdSequenceWithArrayFieldAndXmlValue() returns error? {
+    xml xmlValue = xml `<Root><Source>A</Source><Source>B</Source><Dest>Z</Dest></Root>`;
+    XSDSequenceRecordWithArrayAndXmlValue|Error value = parseAsType(xmlValue);
+    test:assertEquals(value, {seq: {Source: ["A", "B"], Dest: "Z"}});
+    Error? response = validate(xmlValue, XSDSequenceRecordWithArrayAndXmlValue);
+    test:assertTrue(response is ());
+
+    xmlValue = xml `<Root><Source>A</Source><Dest>Z</Dest></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertEquals(value, {seq: {Source: ["A"], Dest: "Z"}});
+    response = validate(xmlValue, XSDSequenceRecordWithArrayAndXmlValue);
+    test:assertTrue(response is ());
+
+    xmlValue = xml `<Root><Dest>Z</Dest><Source>A</Source></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "Element 'Dest' is not in the correct order in 'seq'");
+    response = validate(xmlValue, XSDSequenceRecordWithArrayAndXmlValue);
+    test:assertTrue(response is Error);
+    test:assertEquals((<Error>response).message(), "Invalid XML found: 'Element 'Dest' is not in the correct order in 'seq''");
+}

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1086,3 +1086,101 @@ function testXsdSequenceWithArrayFieldAndXmlValue() returns error? {
     test:assertTrue(response is Error);
     test:assertEquals((<Error>response).message(), "Invalid XML found: 'Element 'Dest' is not in the correct order in 'seq''");
 }
+
+@Name {
+    value: "Root"
+}
+type XSDSequenceRecordWithUnboundedArrayAndXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    Seq_XSDSequenceRecordWithUnboundedArrayAndXmlValue seq;
+|};
+
+type Seq_XSDSequenceRecordWithUnboundedArrayAndXmlValue record {|
+    @SequenceOrder {value: 1}
+    string[] tags;
+    @SequenceOrder {value: 2}
+    string label;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSequenceWithUnboundedArrayFieldAndXmlValue() returns error? {
+    xml xmlValue = xml `<Root><tags>a</tags><label>end</label></Root>`;
+    XSDSequenceRecordWithUnboundedArrayAndXmlValue|Error value = parseAsType(xmlValue);
+    test:assertEquals(value, {seq: {tags: ["a"], label: "end"}});
+    Error? response = validate(xmlValue, XSDSequenceRecordWithUnboundedArrayAndXmlValue);
+    test:assertTrue(response is ());
+
+    xmlValue = xml `<Root><tags>a</tags><tags>b</tags><tags>c</tags><tags>d</tags><tags>e</tags><label>end</label></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertEquals(value, {seq: {tags: ["a", "b", "c", "d", "e"], label: "end"}});
+    response = validate(xmlValue, XSDSequenceRecordWithUnboundedArrayAndXmlValue);
+    test:assertTrue(response is ());
+
+    xmlValue = xml `<Root><label>end</label><tags>a</tags></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "Element 'label' is not in the correct order in 'seq'");
+    response = validate(xmlValue, XSDSequenceRecordWithUnboundedArrayAndXmlValue);
+    test:assertTrue(response is Error);
+    test:assertEquals((<Error>response).message(), "Invalid XML found: 'Element 'label' is not in the correct order in 'seq''");
+
+    xmlValue = xml `<Root><tags>a</tags><tags>b</tags></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "Element(s) 'label' is not found in 'seq'");
+    response = validate(xmlValue, XSDSequenceRecordWithUnboundedArrayAndXmlValue);
+    test:assertTrue(response is Error);
+    test:assertEquals((<Error>response).message(), "Invalid XML found: 'Element(s) 'label' is not found in 'seq''");
+}
+
+@Name {
+    value: "Root"
+}
+type XSDNestedSequenceWithArrayInnerAndXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    OuterArraySeqXmlValue outerSeq;
+|};
+
+type OuterArraySeqXmlValue record {|
+    @SequenceOrder {value: 1}
+    string header;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    OuterArraySeqInnerXmlValue innerSeq;
+|};
+
+type OuterArraySeqInnerXmlValue record {|
+    @SequenceOrder {value: 1}
+    string item;
+    @SequenceOrder {value: 2}
+    int count;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdNestedSequenceWithArrayInnerFieldAndXmlValue() returns error? {
+    xml xmlValue = xml `<Root><header>h1</header><item>x</item><count>3</count></Root>`;
+    XSDNestedSequenceWithArrayInnerAndXmlValue|Error value = parseAsType(xmlValue);
+    test:assertFalse(value is Error, (value is Error) ? (<Error>value).message() : "");
+    test:assertEquals(value, {outerSeq: {header: "h1", innerSeq: {item: "x", count: 3}}});
+    Error? response = validate(xmlValue, XSDNestedSequenceWithArrayInnerAndXmlValue);
+    test:assertTrue(response is ());
+
+    xmlValue = xml `<Root><item>x</item><count>3</count><header>h1</header></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertTrue(value is Error);
+    response = validate(xmlValue, XSDNestedSequenceWithArrayInnerAndXmlValue);
+    test:assertTrue(response is Error);
+
+    xmlValue = xml `<Root><header>h1</header><count>3</count></Root>`;
+    value = parseAsType(xmlValue);
+    test:assertTrue(value is Error);
+    response = validate(xmlValue, XSDNestedSequenceWithArrayInnerAndXmlValue);
+    test:assertTrue(response is Error);
+}

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1052,7 +1052,7 @@ type XSDSequenceRecordWithArrayAndXmlValue record {|
         minOccurs: 0,
         maxOccurs: 1
     }
-    Seq_XSDSequenceRecordWithArrayAndXmlValue seq;
+    Seq_XSDSequenceRecordWithArrayAndXmlValue seq?;
 |};
 
 type Seq_XSDSequenceRecordWithArrayAndXmlValue record {|
@@ -1359,5 +1359,7 @@ function testXsdThreeLevelNestedSeqAndXmlValue() returns error? {
     xmlValue = xml `<Root><level1Field>a</level1Field><level3Field>c</level3Field></Root>`;
     v = parseAsType(xmlValue);
     test:assertTrue(v is Error);
-    check validate(xmlValue, XSDThreeLevelNestedSeqXmlValue);
+    e = validate(xmlValue, XSDThreeLevelNestedSeqXmlValue);
+    test:assertTrue(e is Error);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: 'Element(s) 'level2Field' is not found in 'level2Seq''");
 }

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1363,3 +1363,53 @@ function testXsdThreeLevelNestedSeqAndXmlValue() returns error? {
     test:assertTrue(e is Error);
     test:assertEquals((<Error>e).message(), "Invalid XML found: 'Element(s) 'level2Field' is not found in 'level2Seq''");
 }
+
+type XSDSeqWithSharedElementNameXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithSharedNameXmlValue seqMain;
+|};
+
+type SeqWithSharedNameXmlValue record {|
+    @SequenceOrder {value: 1}
+    string id;
+
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    @SequenceOrder {value: 2}
+    SharedNameNestedXmlValue nested;
+|};
+
+type SharedNameNestedXmlValue record {|
+    @SequenceOrder {value: 1}
+    string name;
+
+    @SequenceOrder {value: 2}
+    string id;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithSharedElementNameAndXmlValue() returns error? {
+    xml xmlValue;
+    XSDSeqWithSharedElementNameXmlValue|Error v;
+
+    xmlValue = xml `<Root><id>parent-id</id><name>some-name</name><id>nested-id</id></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seqMain: {id: "parent-id", nested: {name: "some-name", id: "nested-id"}}});
+    Error? e = validate(xmlValue, XSDSeqWithSharedElementNameXmlValue);
+    test:assertTrue(e is ());
+
+    xmlValue = xml `<Root><name>some-name</name><id>nested-id</id><id>parent-id</id></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    e = validate(xmlValue, XSDSeqWithSharedElementNameXmlValue);
+    test:assertTrue(e is Error);
+
+    xmlValue = xml `<Root><id>parent-id</id><name>some-name</name></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    e = validate(xmlValue, XSDSeqWithSharedElementNameXmlValue);
+    test:assertTrue(e is Error);
+}

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1413,3 +1413,76 @@ function testXsdSeqWithSharedElementNameAndXmlValue() returns error? {
     e = validate(xmlValue, XSDSeqWithSharedElementNameXmlValue);
     test:assertTrue(e is Error);
 }
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testErrorInXsdSeqWithSharedElementNameAndXmlValue() returns error? {
+    xml xmlValue;
+    XSDSeqWithSharedElementNameXmlValue|Error v;
+
+    xmlValue = xml `<Root><age>12</age><id>parent-id</id><name>some-name</name><id>nested-id</id></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+}
+
+@Name {value: "Root"}
+type XSDSeqWithNestedChoiceXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    SeqWithNestedChoiceXmlValue seq_with_choice;
+|};
+
+type SeqWithNestedChoiceXmlValue record {|
+    @SequenceOrder {value: 1}
+    string before;
+
+    @SequenceOrder {value: 2}
+    @Choice {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    ChoiceInSeqXmlValue choice_in_seq;
+
+    @SequenceOrder {value: 3}
+    string after;
+|};
+
+type ChoiceInSeqXmlValue record {|
+    int p?;
+    string q?;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqWithNestedChoiceXmlValue() returns error? {
+    xml xmlValue;
+    XSDSeqWithNestedChoiceXmlValue|Error v;
+
+    xmlValue = xml `<Root><before>start</before><p>1</p><after>end</after></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_with_choice: {before: "start", choice_in_seq: {p: 1}, after: "end"}});
+    Error? e = validate(xmlValue, XSDSeqWithNestedChoiceXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><before>start</before><q>hello</q><after>end</after></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_with_choice: {before: "start", choice_in_seq: {q: "hello"}, after: "end"}});
+    e = validate(xmlValue, XSDSeqWithNestedChoiceXmlValue);
+    test:assertEquals(e, ());
+
+    xmlValue = xml `<Root><before>start</before><p>1</p><q>hello</q><after>end</after></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'choice_in_seq' occurs more than the max allowed times");
+    e = validate(xmlValue, XSDSeqWithNestedChoiceXmlValue);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: ''choice_in_seq' occurs more than the max allowed times'");
+
+    xmlValue = xml `<Root><before>start</before><after>end</after></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'choice_in_seq' is not found in 'seq_with_choice'");
+    e = validate(xmlValue, XSDSeqWithNestedChoiceXmlValue);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: 'Element(s) 'choice_in_seq' is not found in 'seq_with_choice''");
+}

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1420,7 +1420,7 @@ function testErrorInXsdSeqWithSharedElementNameAndXmlValue() returns error? {
     XSDSeqWithSharedElementNameXmlValue|Error v;
 
     xmlValue = xml `<Root><age>12</age><id>parent-id</id><name>some-name</name><id>nested-id</id></Root>`;
-    v = parseAsType(xmlValue);
+    v = parseAsType(xmlValue, {allowDataProjection: false});
     test:assertTrue(v is Error);
 }
 

--- a/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
+++ b/ballerina/tests/xsd_sequence_tests_with_parse_type.bal
@@ -1184,3 +1184,180 @@ function testXsdNestedSequenceWithArrayInnerFieldAndXmlValue() returns error? {
     response = validate(xmlValue, XSDNestedSequenceWithArrayInnerAndXmlValue);
     test:assertTrue(response is Error);
 }
+
+@Name {
+    value: "Root"
+}
+type XSDSeqOptionalLeadingRequiredTrailingXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    Seq_OptionalLeadingRequiredTrailingXmlValue seq_optionalLeadingRequiredTrailing;
+|};
+
+type Seq_OptionalLeadingRequiredTrailingXmlValue record {|
+    @SequenceOrder {value: 1}
+    string optionalElem?;
+
+    @SequenceOrder {value: 2}
+    int requiredElem;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSeqOptionalLeadingRequiredTrailingXmlValue() returns error? {
+    xml xmlValue;
+    XSDSeqOptionalLeadingRequiredTrailingXmlValue|Error v;
+
+    xmlValue = xml `<Root><optionalElem>hello</optionalElem><requiredElem>42</requiredElem></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_optionalLeadingRequiredTrailing: {optionalElem: "hello", requiredElem: 42}});
+    Error? e = validate(xmlValue, XSDSeqOptionalLeadingRequiredTrailingXmlValue);
+    test:assertTrue(e is ());
+
+    xmlValue = xml `<Root><requiredElem>42</requiredElem></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {seq_optionalLeadingRequiredTrailing: {requiredElem: 42}});
+    e = validate(xmlValue, XSDSeqOptionalLeadingRequiredTrailingXmlValue);
+    test:assertTrue(e is ());
+
+    xmlValue = xml `<Root><optionalElem>hello</optionalElem></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "Element(s) 'requiredElem' is not found in 'seq_optionalLeadingRequiredTrailing'");
+    e = validate(xmlValue, XSDSeqOptionalLeadingRequiredTrailingXmlValue);
+    test:assertTrue(e is Error);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: 'Element(s) 'requiredElem' is not found in 'seq_optionalLeadingRequiredTrailing''");
+}
+
+@Name {
+    value: "Root"
+}
+type XSDNestedSeqWithRecordArrayAndXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    OuterSeqRecordArrayXmlValue outerSeqRecordArray;
+|};
+
+type OuterSeqRecordArrayXmlValue record {|
+    @SequenceOrder {value: 1}
+    string header;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 2}
+    InnerSeqRecordArrayXmlValue[] innerSeqs;
+|};
+
+type InnerSeqRecordArrayXmlValue record {|
+    @SequenceOrder {value: 1}
+    string item;
+
+    @SequenceOrder {value: 2}
+    int count;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdNestedSeqWithRecordArrayAndXmlValue() returns error? {
+    xml xmlValue;
+    XSDNestedSeqWithRecordArrayAndXmlValue|Error v;
+
+    xmlValue = xml `<Root><header>h1</header><item>x</item><count>3</count></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outerSeqRecordArray: {header: "h1", innerSeqs: [{item: "x", count: 3}]}});
+    Error? e = validate(xmlValue, XSDNestedSeqWithRecordArrayAndXmlValue);
+    test:assertTrue(e is ());
+
+    xmlValue = xml `<Root><header>h1</header><item>x</item><count>3</count><item>y</item><count>4</count></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {outerSeqRecordArray: {header: "h1", innerSeqs: [{item: "x", count: 3}, {item: "y", count: 4}]}});
+    e = validate(xmlValue, XSDNestedSeqWithRecordArrayAndXmlValue);
+    test:assertTrue(e is ());
+
+    xmlValue = xml `<Root><header>h1</header><item>x</item><count>3</count><item>y</item><count>4</count><item>z</item><count>5</count></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "'innerSeqs' occurs more than the max allowed times");
+    e = validate(xmlValue, XSDNestedSeqWithRecordArrayAndXmlValue);
+    test:assertTrue(e is Error);
+    test:assertEquals((<Error>e).message(), "Invalid XML found: ''innerSeqs' occurs more than the max allowed times'");
+
+    xmlValue = xml `<Root><header>h1</header></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    e = validate(xmlValue, XSDNestedSeqWithRecordArrayAndXmlValue);
+    test:assertTrue(e is Error);
+}
+
+@Name {
+    value: "Root"
+}
+type XSDThreeLevelNestedSeqXmlValue record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    Level1SeqXmlValue level1Seq;
+|};
+
+type Level1SeqXmlValue record {|
+    @SequenceOrder {value: 1}
+    string level1Field;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    Level2SeqXmlValue level2Seq;
+|};
+
+type Level2SeqXmlValue record {|
+    @SequenceOrder {value: 1}
+    string level2Field;
+
+    @SequenceOrder {value: 2}
+    @Sequence {minOccurs: 1, maxOccurs: 1}
+    Level3SeqXmlValue level3Seq;
+|};
+
+type Level3SeqXmlValue record {|
+    @SequenceOrder {value: 1}
+    string level3Field;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdThreeLevelNestedSeqAndXmlValue() returns error? {
+    xml xmlValue;
+    XSDThreeLevelNestedSeqXmlValue|Error v;
+
+    xmlValue = xml `<Root><level1Field>a</level1Field><level2Field>b</level2Field><level3Field>c</level3Field></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertFalse(v is Error, (v is Error) ? (<Error>v).message() : "");
+    test:assertEquals(v, {level1Seq: {level1Field: "a", level2Seq: {level2Field: "b", level3Seq: {level3Field: "c"}}}});
+    Error? e = validate(xmlValue, XSDThreeLevelNestedSeqXmlValue);
+    test:assertTrue(e is ());
+
+    xmlValue = xml `<Root><level2Field>b</level2Field><level1Field>a</level1Field><level3Field>c</level3Field></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    e = validate(xmlValue, XSDThreeLevelNestedSeqXmlValue);
+    test:assertTrue(e is Error);
+
+    xmlValue = xml `<Root><level1Field>a</level1Field><level2Field>b</level2Field></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    test:assertTrue((<Error>v).message() == "Element(s) 'level3Field' is not found in 'level3Seq'" ||
+        (<Error>v).message() == "Element(s) 'level3Seq' is not found in 'level2Seq'");
+    e = validate(xmlValue, XSDThreeLevelNestedSeqXmlValue);
+    test:assertTrue(e is Error);
+    test:assertTrue((<Error>e).message() == "Invalid XML found: 'Element(s) 'level3Field' is not found in 'level3Seq''" ||
+        (<Error>e).message() == "Invalid XML found: 'Element(s) 'level3Seq' is not found in 'level2Seq''");
+
+    xmlValue = xml `<Root><level1Field>a</level1Field><level3Field>c</level3Field></Root>`;
+    v = parseAsType(xmlValue);
+    test:assertTrue(v is Error);
+    check validate(xmlValue, XSDThreeLevelNestedSeqXmlValue);
+}

--- a/ballerina/tests/xsd_test_with_invalid_records.bal
+++ b/ballerina/tests/xsd_test_with_invalid_records.bal
@@ -95,3 +95,38 @@ function testXsdChoiceWithInvalidRecord() returns error? {
     XSDChoiceInvalidRecord|Error v4 = parseString(xmlStr);
     test:assertEquals((<Error>v4).message(), "Cannot include Choice annotation into 'a' of type 'int'");
 }
+
+type XSDSequenceWithUndefinedFieldRecord record {|
+    @Sequence {
+        minOccurs: 1,
+        maxOccurs: 1
+    }
+    Seq_XSDSequenceWithUndefinedField seq_XSDSequenceWithUndefinedField;
+|};
+
+type Seq_XSDSequenceWithUndefinedField record {|
+    @SequenceOrder {
+        value: 1
+    }
+    int age;
+
+    @SequenceOrder {
+        value: 2
+    }
+    float salary;
+|};
+
+@test:Config {groups: ["xsd", "xsd_sequence"]}
+function testXsdSequenceWithUndefinedField() returns error? {
+    string xmlStr = string `<Root><age>13</age><salary>11.1</salary></Root>`;
+    XSDSequenceWithUndefinedFieldRecord|Error v = parseString(xmlStr);
+    test:assertEquals(v, {seq_XSDSequenceWithUndefinedField: {age: 13, salary: 11.1}});
+
+    xmlStr = string `<Root><age>13</age><salary>11.1</salary><unknown>value</unknown></Root>`;
+    v = parseString(xmlStr);
+    test:assertEquals(v, {seq_XSDSequenceWithUndefinedField: {age: 13, salary: 11.1}});
+
+    v = parseString(xmlStr, {allowDataProjection: false});
+    test:assertTrue(v is Error);
+    test:assertEquals((<Error>v).message(), "undefined field 'unknown' in record 'data.xmldata:XSDSequenceWithUndefinedFieldRecord'");
+}

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
@@ -197,11 +197,17 @@ public static void popXsdValidationStacks(XmlAnalyzerMetaData xmlAnalyzerMetaDat
         if (isTerminated) {
             modelGroup.validateMinOccurrences();
         }
+        String completedFieldName = modelGroup.getFieldName();
         xmlAnalyzerMetaData.currentNode = (BMap<BString, Object>) xmlAnalyzerMetaData.nodesStack.pop();
         xmlAnalyzerMetaData.modelGroupStack.pop();
         xmlAnalyzerMetaData.rootRecord = xmlAnalyzerMetaData.recordTypeStack.pop();
         validateCurrentElementInfo(xmlAnalyzerMetaData);
         popElementStacksForValidatingGroup(xmlAnalyzerMetaData);
+        // Notify the outer model group that the inner nested sequence has completed,
+        // so the outer sequence can update its element-order tracking state.
+        if (!xmlAnalyzerMetaData.modelGroupStack.isEmpty()) {
+            xmlAnalyzerMetaData.modelGroupStack.peek().notifyNestedGroupCompleted(completedFieldName);
+        }
     }
 
     private static void initializeAnyAnnotatedArrayFields(BMap<BString, Object> recordValue, RecordType recordType) {

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
@@ -202,6 +202,14 @@ public static void popXsdValidationStacks(XmlAnalyzerMetaData xmlAnalyzerMetaDat
         xmlAnalyzerMetaData.modelGroupStack.pop();
         xmlAnalyzerMetaData.rootRecord = xmlAnalyzerMetaData.recordTypeStack.pop();
         validateCurrentElementInfo(xmlAnalyzerMetaData);
+        if (modelGroup instanceof ChoiceInfo && !xmlAnalyzerMetaData.xsdModelGroupInfo.isEmpty()) {
+            ChoiceInfo choiceInfo = (ChoiceInfo) modelGroup;
+            xmlAnalyzerMetaData.xsdModelGroupInfo.peek().forEach((key, nestedGroup) -> {
+                if (choiceInfo.isUnusedNestedGroupField(key)) {
+                    nestedGroup.notifyNestedGroupCompleted(null);
+                }
+            });
+        }
         popElementStacksForValidatingGroup(xmlAnalyzerMetaData);
         if (!xmlAnalyzerMetaData.modelGroupStack.isEmpty()) {
             xmlAnalyzerMetaData.modelGroupStack.peek().notifyNestedGroupCompleted(completedFieldName);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
@@ -203,8 +203,6 @@ public static void popXsdValidationStacks(XmlAnalyzerMetaData xmlAnalyzerMetaDat
         xmlAnalyzerMetaData.rootRecord = xmlAnalyzerMetaData.recordTypeStack.pop();
         validateCurrentElementInfo(xmlAnalyzerMetaData);
         popElementStacksForValidatingGroup(xmlAnalyzerMetaData);
-        // Notify the outer model group that the inner nested sequence has completed,
-        // so the outer sequence can update its element-order tracking state.
         if (!xmlAnalyzerMetaData.modelGroupStack.isEmpty()) {
             xmlAnalyzerMetaData.modelGroupStack.peek().notifyNestedGroupCompleted(completedFieldName);
         }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/XsdUtils.java
@@ -193,6 +193,13 @@ public static void popXsdValidationStacks(XmlAnalyzerMetaData xmlAnalyzerMetaDat
     public static void validateModelGroup(ModelGroupInfo modelGroup,
                                           XmlAnalyzerMetaData xmlAnalyzerMetaData, boolean isTerminated) {
         initializeAnyAnnotatedArrayFields(xmlAnalyzerMetaData.currentNode, xmlAnalyzerMetaData.rootRecord);
+        if (modelGroup instanceof ChoiceInfo choiceInfo && !xmlAnalyzerMetaData.xsdModelGroupInfo.isEmpty()) {
+            xmlAnalyzerMetaData.xsdModelGroupInfo.peek().forEach((key, nestedGroup) -> {
+                if (choiceInfo.isUnusedNestedGroupField(key)) {
+                    nestedGroup.notifyNestedGroupCompleted(null);
+                }
+            });
+        }
         modelGroup.validate();
         if (isTerminated) {
             modelGroup.validateMinOccurrences();
@@ -202,14 +209,6 @@ public static void popXsdValidationStacks(XmlAnalyzerMetaData xmlAnalyzerMetaDat
         xmlAnalyzerMetaData.modelGroupStack.pop();
         xmlAnalyzerMetaData.rootRecord = xmlAnalyzerMetaData.recordTypeStack.pop();
         validateCurrentElementInfo(xmlAnalyzerMetaData);
-        if (modelGroup instanceof ChoiceInfo && !xmlAnalyzerMetaData.xsdModelGroupInfo.isEmpty()) {
-            ChoiceInfo choiceInfo = (ChoiceInfo) modelGroup;
-            xmlAnalyzerMetaData.xsdModelGroupInfo.peek().forEach((key, nestedGroup) -> {
-                if (choiceInfo.isUnusedNestedGroupField(key)) {
-                    nestedGroup.notifyNestedGroupCompleted(null);
-                }
-            });
-        }
         popElementStacksForValidatingGroup(xmlAnalyzerMetaData);
         if (!xmlAnalyzerMetaData.modelGroupStack.isEmpty()) {
             xmlAnalyzerMetaData.modelGroupStack.peek().notifyNestedGroupCompleted(completedFieldName);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ChoiceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ChoiceInfo.java
@@ -147,6 +147,7 @@ public class ChoiceInfo implements ModelGroupInfo {
         this.remainingElementCount.putAll(this.maxElementCount);
         this.lastElement = "";
         this.containElements.clear();
+        this.usedNestedGroupFieldNames.clear();
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ChoiceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ChoiceInfo.java
@@ -22,10 +22,17 @@ import io.ballerina.lib.data.xmldata.utils.Constants;
 import io.ballerina.lib.data.xmldata.utils.DataUtils;
 import io.ballerina.lib.data.xmldata.utils.DiagnosticErrorCode;
 import io.ballerina.lib.data.xmldata.utils.DiagnosticLog;
+import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.RecordType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.TypeTags;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -38,6 +45,8 @@ import java.util.Stack;
  * @since 1.1.0
  */
 public class ChoiceInfo implements ModelGroupInfo {
+
+    private static final String SPECIAL_CHAR_REGEX = "\\\\$0";
 
     private final Stack<HashMap<String, ElementInfo>> xmlElementInfo;
     private final Map<String, Integer> remainingElementCount = new HashMap<>();
@@ -55,6 +64,9 @@ public class ChoiceInfo implements ModelGroupInfo {
     private final HashMap<String, String> xmlElementNameMap;
     private boolean isMiddleOfElement = false;
     private final boolean isArrayField;
+    private final Set<String> nestedGroupElements = new HashSet<>();
+    private final Set<String> nestedGroupFieldNames = new HashSet<>();
+    private final Set<String> usedNestedGroupFieldNames = new HashSet<>();
 
 
     public ChoiceInfo(String fieldName, BMap<BString, Object> element, RecordType fieldType,
@@ -77,6 +89,7 @@ public class ChoiceInfo implements ModelGroupInfo {
         reOrderElementNamesBasedOnTheNameAnnotation();
         this.xmlElementInfo = xmlElementInfo;
         this.isArrayField = isArrayField;
+        buildNestedGroupElements(fieldType);
         if (isArrayField) {
             initElementCountsFromFieldType(fieldType);
         }
@@ -143,6 +156,10 @@ public class ChoiceInfo implements ModelGroupInfo {
             return;
         }
 
+        if (nestedGroupElements.contains(element)) {
+            return;
+        }
+
         isMiddleOfElement = isStartElement;
 
         if (isStartElement) {
@@ -179,7 +196,46 @@ public class ChoiceInfo implements ModelGroupInfo {
 
     @Override
     public boolean isElementContains(String elementName) {
-        return allElements.contains(elementName);
+        return allElements.contains(elementName) || nestedGroupElements.contains(elementName);
+    }
+
+    @Override
+    public void notifyNestedGroupCompleted(String completedFieldName) {
+        if (completedFieldName == null) {
+            this.occurrences = (int) this.minOccurs;
+            return;
+        }
+        String xmlElementName = getXmlElementNameFromFieldName(completedFieldName);
+        if (!nestedGroupFieldNames.contains(xmlElementName)) {
+            return;
+        }
+        usedNestedGroupFieldNames.add(xmlElementName);
+        generateElementOptionalityMapIfNotPresent();
+        Integer remaining = remainingElementCount.get(xmlElementName);
+        if (remaining == null) {
+            remainingElementCount.put(xmlElementName, 1);
+            maxElementCount.put(xmlElementName, 1);
+            minimumElementCount.put(xmlElementName, 1);
+            remaining = 1;
+        }
+        remainingElementCount.put(xmlElementName, remaining - 1);
+        containElements.add(xmlElementName);
+        if (!visitedElements.contains(xmlElementName)) {
+            int count = maxElementCount.get(xmlElementName) - remainingElementCount.get(xmlElementName);
+            if (count >= minimumElementCount.get(xmlElementName)) {
+                visitedElements.add(xmlElementName);
+                updateOccurrences();
+            }
+        }
+    }
+
+    private String getXmlElementNameFromFieldName(String fieldName) {
+        for (Map.Entry<String, String> entry : xmlElementNameMap.entrySet()) {
+            if (entry.getValue().equals(fieldName)) {
+                return entry.getKey();
+            }
+        }
+        return fieldName;
     }
 
     @Override
@@ -234,12 +290,115 @@ public class ChoiceInfo implements ModelGroupInfo {
         }
     }
 
+    private void buildNestedGroupElements(RecordType recordType) {
+        BMap<BString, Object> annotations = recordType.getAnnotations();
+        for (String xmlElementName : allElements) {
+            String fName = xmlElementNameMap.getOrDefault(xmlElementName, xmlElementName);
+            if (isFieldAnnotatedWithModuleSequence(annotations, fName)) {
+                nestedGroupFieldNames.add(xmlElementName);
+                Field field = recordType.getFields().get(fName);
+                if (field != null) {
+                    Type fType = TypeUtils.getReferredType(field.getFieldType());
+                    collectNestedGroupElements(fType, nestedGroupElements, true);
+                }
+            } else if (isFieldAnnotatedWithModuleChoice(annotations, fName)) {
+                nestedGroupFieldNames.add(xmlElementName);
+                Field field = recordType.getFields().get(fName);
+                if (field != null) {
+                    Type fType = TypeUtils.getReferredType(field.getFieldType());
+                    collectNestedGroupElements(fType, nestedGroupElements, false);
+                }
+            }
+        }
+    }
+
+    private static void collectNestedGroupElements(Type type, Set<String> result, boolean isSequence) {
+        RecordType recordType = null;
+        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            recordType = (RecordType) type;
+        } else if (type.getTag() == TypeTags.ARRAY_TAG) {
+            Type elementType = TypeUtils.getReferredType(((ArrayType) type).getElementType());
+            if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                recordType = (RecordType) elementType;
+            }
+        }
+        if (recordType == null) {
+            return;
+        }
+
+        BMap<BString, Object> annotations = recordType.getAnnotations();
+        HashMap<String, String> elementNameMap = DataUtils.getXmlElementNameMap(recordType);
+        HashMap<String, String> fieldToXmlName = new HashMap<>();
+        elementNameMap.forEach((xmlName, fieldName) -> fieldToXmlName.put(fieldName, xmlName));
+
+        Collection<String> fieldNames;
+        if (isSequence) {
+            fieldNames = DataUtils.getXsdSequencePriorityOrder(recordType, true).keySet();
+        } else {
+            fieldNames = recordType.getFields().keySet();
+        }
+
+        for (String fieldName : fieldNames) {
+            String xmlElementName = fieldToXmlName.getOrDefault(fieldName, fieldName);
+            if (isFieldAnnotatedWithModuleSequence(annotations, fieldName)) {
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    collectNestedGroupElements(TypeUtils.getReferredType(field.getFieldType()), result, true);
+                }
+            } else if (isFieldAnnotatedWithModuleChoice(annotations, fieldName)) {
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    collectNestedGroupElements(TypeUtils.getReferredType(field.getFieldType()), result, false);
+                }
+            } else {
+                result.add(xmlElementName);
+            }
+        }
+    }
+
+    private static boolean isFieldAnnotatedWithModuleSequence(BMap<BString, Object> annotations, String fieldName) {
+        BString annotationKey = StringUtils.fromString(Constants.FIELD
+                + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, SPECIAL_CHAR_REGEX));
+        BMap<BString, Object> fieldAnnotation = (BMap<BString, Object>) annotations.get(annotationKey);
+        if (fieldAnnotation == null) {
+            return false;
+        }
+        for (BString key : fieldAnnotation.getKeys()) {
+            String keyStr = key.getValue();
+            if (keyStr.startsWith(Constants.MODULE_NAME) && keyStr.endsWith(Constants.SEQUENCE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isFieldAnnotatedWithModuleChoice(BMap<BString, Object> annotations, String fieldName) {
+        BString annotationKey = StringUtils.fromString(Constants.FIELD
+                + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, SPECIAL_CHAR_REGEX));
+        BMap<BString, Object> fieldAnnotation = (BMap<BString, Object>) annotations.get(annotationKey);
+        if (fieldAnnotation == null) {
+            return false;
+        }
+        for (BString key : fieldAnnotation.getKeys()) {
+            String keyStr = key.getValue();
+            if (keyStr.startsWith(Constants.MODULE_NAME) && keyStr.endsWith(Constants.CHOICE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void reOrderElementNamesBasedOnTheNameAnnotation() {
         allElements.forEach(element -> {
             if (!xmlElementNameMap.containsKey(element)) {
                 xmlElementNameMap.put(element, element);
             }
         });
+    }
+
+    public boolean isUnusedNestedGroupField(String fieldName) {
+        String xmlName = getXmlElementNameFromFieldName(fieldName);
+        return nestedGroupFieldNames.contains(xmlName) && !usedNestedGroupFieldNames.contains(xmlName);
     }
 
     public long getMinOccurs() {

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ModelGroupInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ModelGroupInfo.java
@@ -33,4 +33,14 @@ public interface ModelGroupInfo {
     long getMinOccurs();
     long getMaxOccurs();
     String getFieldName();
+
+    /**
+     * Notifies this model group that a nested sequence field has completed.
+     * This allows the outer sequence to update its state as if the nested sequence field was visited.
+     *
+     * @param fieldName the field name of the completed nested sequence
+     */
+    default void notifyNestedGroupCompleted(String fieldName) {
+        // Default no-op; overridden in SequenceInfo for nested sequence support
+    }
 }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ModelGroupInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ModelGroupInfo.java
@@ -34,13 +34,7 @@ public interface ModelGroupInfo {
     long getMaxOccurs();
     String getFieldName();
 
-    /**
-     * Notifies this model group that a nested sequence field has completed.
-     * This allows the outer sequence to update its state as if the nested sequence field was visited.
-     *
-     * @param fieldName the field name of the completed nested sequence
-     */
     default void notifyNestedGroupCompleted(String fieldName) {
-        // Default no-op; overridden in SequenceInfo for nested sequence support
+        // Implemented in SequenceInfo for nested sequence support
     }
 }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ModelGroupInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/ModelGroupInfo.java
@@ -33,8 +33,5 @@ public interface ModelGroupInfo {
     long getMinOccurs();
     long getMaxOccurs();
     String getFieldName();
-
-    default void notifyNestedGroupCompleted(String fieldName) {
-        // Implemented in SequenceInfo for nested sequence support
-    }
+    void notifyNestedGroupCompleted(String fieldName);
 }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -232,10 +232,6 @@ public class SequenceInfo implements ModelGroupInfo {
                         xmlElementNameMap.getOrDefault(element, element), fieldName);
             }
             currentIndex++;
-            if (currentIndex == this.elementCount) {
-                throw DiagnosticLog.error(DiagnosticErrorCode.INCORRECT_ELEMENT_ORDER,
-                        xmlElementNameMap.getOrDefault(element, element), fieldName);
-            }
             nextElement = allElements.get(currentIndex);
         }
 
@@ -314,15 +310,9 @@ public class SequenceInfo implements ModelGroupInfo {
     }
 
     private boolean isArrayField(String element) {
-        if (fieldType == null) {
-            return false;
-        }
         String fieldName = xmlElementNameMap.getOrDefault(element, element);
         Field field = fieldType.getFields().get(fieldName);
-        if (field == null) {
-            return false;
-        }
-        return field.getFieldType().getTag() == TypeTags.ARRAY_TAG;
+        return field != null && field.getFieldType().getTag() == TypeTags.ARRAY_TAG;
     }
 
     private int getMaxValue(String element) {
@@ -378,9 +368,6 @@ public class SequenceInfo implements ModelGroupInfo {
     private static boolean isFieldAnnotatedWithModuleSequence(BMap<BString, Object> annotations, String fieldName) {
         BString annotationKey = StringUtils.fromString(Constants.FIELD
                 + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, SPECIAL_CHAR_REGEX));
-        if (!annotations.containsKey(annotationKey)) {
-            return false;
-        }
         BMap<BString, Object> fieldAnnotation = (BMap<BString, Object>) annotations.get(annotationKey);
         for (BString key : fieldAnnotation.getKeys()) {
             String keyStr = key.getValue();
@@ -400,9 +387,6 @@ public class SequenceInfo implements ModelGroupInfo {
             if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
                 recordType = (RecordType) elementType;
             }
-        }
-        if (recordType == null) {
-            return;
         }
 
         BMap<BString, Object> annotations = recordType.getAnnotations();

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -333,7 +333,7 @@ public class SequenceInfo implements ModelGroupInfo {
     private boolean isArrayField(String element) {
         String fieldName = xmlElementNameMap.getOrDefault(element, element);
         Field field = fieldType.getFields().get(fieldName);
-        return field != null && field.getFieldType().getTag() == TypeTags.ARRAY_TAG;
+        return field != null && TypeUtils.getReferredType(field.getFieldType()).getTag() == TypeTags.ARRAY_TAG;
     }
 
     private int getMaxValue(String element) {
@@ -426,11 +426,12 @@ public class SequenceInfo implements ModelGroupInfo {
     }
 
     private static void collectNestedSequenceElements(Type type, Set<String> result) {
+        Type referredType = TypeUtils.getReferredType(type);
         RecordType recordType = null;
-        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            recordType = (RecordType) type;
-        } else if (type.getTag() == TypeTags.ARRAY_TAG) {
-            Type elementType = TypeUtils.getReferredType(((ArrayType) type).getElementType());
+        if (referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            recordType = (RecordType) referredType;
+        } else if (referredType.getTag() == TypeTags.ARRAY_TAG) {
+            Type elementType = TypeUtils.getReferredType(((ArrayType) referredType).getElementType());
             if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
                 recordType = (RecordType) elementType;
             }
@@ -462,11 +463,12 @@ public class SequenceInfo implements ModelGroupInfo {
     }
 
     private static void collectNestedChoiceElements(Type type, Set<String> result) {
+        Type referredType = TypeUtils.getReferredType(type);
         RecordType recordType = null;
-        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            recordType = (RecordType) type;
-        } else if (type.getTag() == TypeTags.ARRAY_TAG) {
-            Type elementType = TypeUtils.getReferredType(((ArrayType) type).getElementType());
+        if (referredType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            recordType = (RecordType) referredType;
+        } else if (referredType.getTag() == TypeTags.ARRAY_TAG) {
+            Type elementType = TypeUtils.getReferredType(((ArrayType) referredType).getElementType());
             if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
                 recordType = (RecordType) elementType;
             }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -47,6 +47,7 @@ import java.util.Stack;
  * @since 1.1.0
  */
 public class SequenceInfo implements ModelGroupInfo {
+    public static final String SPECIAL_CHAR_REGEX = "\\\\$0";
     public String fieldName;
     public long minOccurs;
     public long maxOccurs;
@@ -127,8 +128,6 @@ public class SequenceInfo implements ModelGroupInfo {
             return;
         }
 
-        // Elements that belong to nested sequences are tracked by inner model groups.
-        // The outer sequence state is updated via notifyNestedGroupCompleted when the inner group completes.
         if (nestedSequenceElements.contains(element)) {
             return;
         }
@@ -144,8 +143,6 @@ public class SequenceInfo implements ModelGroupInfo {
 
     @Override
     public void notifyNestedGroupCompleted(String fieldName) {
-        // Only update state if fieldName is a direct nested sequence field of this group.
-        // Other inner model groups (e.g., sequence fields within element-typed fields) are not tracked here.
         if (!nestedSequenceFieldNames.contains(fieldName)) {
             return;
         }
@@ -390,7 +387,7 @@ public class SequenceInfo implements ModelGroupInfo {
 
     private static boolean isFieldAnnotatedWithModuleSequence(BMap<BString, Object> annotations, String fieldName) {
         BString annotationKey = StringUtils.fromString(Constants.FIELD
-                + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, "\\\\$0"));
+                + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, SPECIAL_CHAR_REGEX));
         if (!annotations.containsKey(annotationKey)) {
             return false;
         }
@@ -422,7 +419,6 @@ public class SequenceInfo implements ModelGroupInfo {
         HashMap<String, Integer> priorityOrder = DataUtils.getXsdSequencePriorityOrder(recordType, true);
         HashMap<String, String> elementNameMap = DataUtils.getXmlElementNameMap(recordType);
 
-        // Build reverse map: fieldName -> xmlElementName
         HashMap<String, String> fieldToXmlName = new HashMap<>();
         elementNameMap.forEach((xmlName, fieldName) -> fieldToXmlName.put(fieldName, xmlName));
 

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -231,12 +231,11 @@ public class SequenceInfo implements ModelGroupInfo {
                         xmlElementNameMap.getOrDefault(element, element), fieldName);
             }
             currentIndex++;
-            nextElement = allElements.get(currentIndex);
-
             if (currentIndex == this.elementCount) {
                 throw DiagnosticLog.error(DiagnosticErrorCode.INCORRECT_ELEMENT_ORDER,
                         xmlElementNameMap.getOrDefault(element, element), fieldName);
             }
+            nextElement = allElements.get(currentIndex);
         }
 
         if (remainingElementCount.get(nextElement) == 0) {

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -224,6 +224,10 @@ public class SequenceInfo implements ModelGroupInfo {
 
         while (!nextElement.equals(elementToProcess)) {
             if (!elementOptionality.get(nextElement)) {
+                if (nestedSequenceFieldNames.contains(elementToProcess)) {
+                    throw DiagnosticLog.error(DiagnosticErrorCode.REQUIRED_ELEMENT_NOT_FOUND,
+                            xmlElementNameMap.getOrDefault(nextElement, nextElement), fieldName);
+                }
                 throw DiagnosticLog.error(DiagnosticErrorCode.INCORRECT_ELEMENT_ORDER,
                         xmlElementNameMap.getOrDefault(element, element), fieldName);
             }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -341,7 +341,7 @@ public class SequenceInfo implements ModelGroupInfo {
         if (maxOccurs > 0 && isArray) {
             return (int) maxOccurs;
         } else if (isArray) {
-            return Integer.MAX_VALUE;
+            return Character.MAX_VALUE;
         }
         return 1;
     }

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -23,16 +23,22 @@ import io.ballerina.lib.data.xmldata.utils.DataUtils;
 import io.ballerina.lib.data.xmldata.utils.DiagnosticErrorCode;
 import io.ballerina.lib.data.xmldata.utils.DiagnosticLog;
 import io.ballerina.runtime.api.flags.SymbolFlags;
+import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.RecordType;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeTags;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Stack;
 
 /**
@@ -51,6 +57,8 @@ public class SequenceInfo implements ModelGroupInfo {
     private final Map<String, Boolean> elementOptionality = new HashMap<>();
     private final List<String> allElements = new ArrayList<>();
     private final List<String> anyAnnotatedFields = new ArrayList<>();
+    private final Set<String> nestedSequenceElements = new HashSet<>();
+    private final Set<String> nestedSequenceFieldNames = new HashSet<>();
     int currentIndex = 0;
     int elementCount;
     String lastElement = "";
@@ -81,6 +89,7 @@ public class SequenceInfo implements ModelGroupInfo {
         this.xmlElementNameMap = DataUtils.getXmlElementNameMap(fieldType);
         reOrderElementNamesBasedOnTheNameAnnotation();
         this.elementCount = allElements.size();
+        buildNestedSequenceElements(fieldType);
     }
 
     public void updateOccurrences() {
@@ -118,6 +127,12 @@ public class SequenceInfo implements ModelGroupInfo {
             return;
         }
 
+        // Elements that belong to nested sequences are tracked by inner model groups.
+        // The outer sequence state is updated via notifyNestedGroupCompleted when the inner group completes.
+        if (nestedSequenceElements.contains(element)) {
+            return;
+        }
+
         isMiddleOfElement = isStartElement;
         if (isStartElement) {
             isCompleted = false;
@@ -125,6 +140,17 @@ public class SequenceInfo implements ModelGroupInfo {
         }
 
         checkElementOrderAndUpdateElementOccurences(element);
+    }
+
+    @Override
+    public void notifyNestedGroupCompleted(String fieldName) {
+        // Only update state if fieldName is a direct nested sequence field of this group.
+        // Other inner model groups (e.g., sequence fields within element-typed fields) are not tracked here.
+        if (!nestedSequenceFieldNames.contains(fieldName)) {
+            return;
+        }
+        generateElementOptionalityMapIfNotPresent();
+        checkElementOrderAndUpdateElementOccurences(fieldName);
     }
 
     @Override
@@ -136,6 +162,9 @@ public class SequenceInfo implements ModelGroupInfo {
             return true;
         }
         if (!anyAnnotatedFields.isEmpty()) {
+            return true;
+        }
+        if (this.nestedSequenceElements.contains(elementName)) {
             return true;
         }
         return false;
@@ -340,6 +369,75 @@ public class SequenceInfo implements ModelGroupInfo {
             return true;
         }
         return anyAnnotatedFields.contains(fieldName);
+    }
+
+    private void buildNestedSequenceElements(RecordType recordType) {
+        if (recordType == null) {
+            return;
+        }
+        BMap<BString, Object> annotations = recordType.getAnnotations();
+        for (String xmlElementName : allElements) {
+            String fieldName = xmlElementNameMap.getOrDefault(xmlElementName, xmlElementName);
+            if (isFieldAnnotatedWithModuleSequence(annotations, fieldName)) {
+                nestedSequenceFieldNames.add(xmlElementName);
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    Type fType = TypeUtils.getReferredType(field.getFieldType());
+                    collectNestedSequenceElements(fType, nestedSequenceElements);
+                }
+            }
+        }
+    }
+
+    private static boolean isFieldAnnotatedWithModuleSequence(BMap<BString, Object> annotations, String fieldName) {
+        BString annotationKey = StringUtils.fromString(Constants.FIELD
+                + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, "\\\\$0"));
+        if (!annotations.containsKey(annotationKey)) {
+            return false;
+        }
+        BMap<BString, Object> fieldAnnotation = (BMap<BString, Object>) annotations.get(annotationKey);
+        for (BString key : fieldAnnotation.getKeys()) {
+            String keyStr = key.getValue();
+            if (keyStr.startsWith(Constants.MODULE_NAME) && keyStr.endsWith(Constants.SEQUENCE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void collectNestedSequenceElements(Type type, Set<String> result) {
+        RecordType recordType = null;
+        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            recordType = (RecordType) type;
+        } else if (type.getTag() == TypeTags.ARRAY_TAG) {
+            Type elementType = TypeUtils.getReferredType(((ArrayType) type).getElementType());
+            if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                recordType = (RecordType) elementType;
+            }
+        }
+        if (recordType == null) {
+            return;
+        }
+
+        BMap<BString, Object> annotations = recordType.getAnnotations();
+        HashMap<String, Integer> priorityOrder = DataUtils.getXsdSequencePriorityOrder(recordType, true);
+        HashMap<String, String> elementNameMap = DataUtils.getXmlElementNameMap(recordType);
+
+        // Build reverse map: fieldName -> xmlElementName
+        HashMap<String, String> fieldToXmlName = new HashMap<>();
+        elementNameMap.forEach((xmlName, fieldName) -> fieldToXmlName.put(fieldName, xmlName));
+
+        for (String fieldName : priorityOrder.keySet()) {
+            String xmlElementName = fieldToXmlName.getOrDefault(fieldName, fieldName);
+            if (isFieldAnnotatedWithModuleSequence(annotations, fieldName)) {
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    collectNestedSequenceElements(TypeUtils.getReferredType(field.getFieldType()), result);
+                }
+            } else {
+                result.add(xmlElementName);
+            }
+        }
     }
 
     private void reOrderElementNamesBasedOnTheNameAnnotation() {

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -289,34 +289,23 @@ public class SequenceInfo implements ModelGroupInfo {
 
     private void generateElementOptionalityMapIfNotPresent() {
         if (elementOptionality.isEmpty()) {
-            if (!xmlElementInfo.isEmpty()) {
-                allElements.forEach(element -> {
-                    HashMap<String, ElementInfo> elementInfo = xmlElementInfo.peek();
-                    if (elementInfo.containsKey(element)) {
-                        ElementInfo info = elementInfo.get(element);
-                        elementOptionality.put(element, info.minOccurs == 0);
-                        remainingElementCount.put(element, (int) info.maxOccurs);
-                        maxElementCount.put(element, (int) info.maxOccurs);
-                        minimumElementCount.put(element, (int) info.minOccurs);
-                    } else {
-                        boolean isOptional = isFieldOptional(element);
-                        int maxValue = getMaxValue(element);
-                        elementOptionality.put(element, isOptional);
-                        remainingElementCount.put(element, maxValue);
-                        maxElementCount.put(element, maxValue);
-                        minimumElementCount.put(element, isOptional ? 0 : 1);
-                    }
-                });
-            } else {
-                allElements.forEach(element -> {
+            allElements.forEach(element -> {
+                HashMap<String, ElementInfo> elementInfo = xmlElementInfo.peek();
+                if (elementInfo.containsKey(element)) {
+                    ElementInfo info = elementInfo.get(element);
+                    elementOptionality.put(element, info.minOccurs == 0);
+                    remainingElementCount.put(element, (int) info.maxOccurs);
+                    maxElementCount.put(element, (int) info.maxOccurs);
+                    minimumElementCount.put(element, (int) info.minOccurs);
+                } else {
                     boolean isOptional = isFieldOptional(element);
                     int maxValue = getMaxValue(element);
                     elementOptionality.put(element, isOptional);
                     remainingElementCount.put(element, maxValue);
                     maxElementCount.put(element, maxValue);
                     minimumElementCount.put(element, isOptional ? 0 : 1);
-                });
-            }
+                }
+            });
         }
     }
 
@@ -368,9 +357,6 @@ public class SequenceInfo implements ModelGroupInfo {
     }
 
     private void buildNestedSequenceElements(RecordType recordType) {
-        if (recordType == null) {
-            return;
-        }
         BMap<BString, Object> annotations = recordType.getAnnotations();
         for (String xmlElementName : allElements) {
             String fieldName = xmlElementNameMap.getOrDefault(xmlElementName, xmlElementName);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -129,7 +129,10 @@ public class SequenceInfo implements ModelGroupInfo {
         }
 
         if (nestedSequenceElements.contains(element)) {
-            return;
+            int directChildIdx = allElements.indexOf(element);
+            if (directChildIdx < 0 || currentIndex > directChildIdx) {
+                return;
+            }
         }
 
         isMiddleOfElement = isStartElement;

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -60,6 +60,7 @@ public class SequenceInfo implements ModelGroupInfo {
     private final List<String> anyAnnotatedFields = new ArrayList<>();
     private final Set<String> nestedSequenceElements = new HashSet<>();
     private final Set<String> nestedSequenceFieldNames = new HashSet<>();
+    private final Set<String> nestedChoiceFieldNames = new HashSet<>();
     int currentIndex = 0;
     int elementCount;
     String lastElement = "";
@@ -146,8 +147,12 @@ public class SequenceInfo implements ModelGroupInfo {
 
     @Override
     public void notifyNestedGroupCompleted(String fieldName) {
+        if (fieldName == null) {
+            this.occurrences = (int) this.minOccurs;
+            return;
+        }
         String xmlElementName = getXmlElementNameFromFieldName(fieldName);
-        if (!nestedSequenceFieldNames.contains(xmlElementName)) {
+        if (!nestedSequenceFieldNames.contains(xmlElementName) && !nestedChoiceFieldNames.contains(xmlElementName)) {
             return;
         }
         generateElementOptionalityMapIfNotPresent();
@@ -237,7 +242,10 @@ public class SequenceInfo implements ModelGroupInfo {
 
         while (!nextElement.equals(elementToProcess)) {
             if (!elementOptionality.get(nextElement)) {
-                if (nestedSequenceFieldNames.contains(elementToProcess)) {
+                if (nestedSequenceFieldNames.contains(elementToProcess)
+                        || nestedChoiceFieldNames.contains(elementToProcess)
+                        || nestedSequenceFieldNames.contains(nextElement)
+                        || nestedChoiceFieldNames.contains(nextElement)) {
                     throw DiagnosticLog.error(DiagnosticErrorCode.REQUIRED_ELEMENT_NOT_FOUND,
                             xmlElementNameMap.getOrDefault(nextElement, nextElement), fieldName);
                 }
@@ -374,6 +382,13 @@ public class SequenceInfo implements ModelGroupInfo {
                     Type fType = TypeUtils.getReferredType(field.getFieldType());
                     collectNestedSequenceElements(fType, nestedSequenceElements);
                 }
+            } else if (isFieldAnnotatedWithModuleChoice(annotations, fieldName)) {
+                nestedChoiceFieldNames.add(xmlElementName);
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    Type fType = TypeUtils.getReferredType(field.getFieldType());
+                    collectNestedChoiceElements(fType, nestedSequenceElements);
+                }
             }
         }
     }
@@ -382,9 +397,28 @@ public class SequenceInfo implements ModelGroupInfo {
         BString annotationKey = StringUtils.fromString(Constants.FIELD
                 + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, SPECIAL_CHAR_REGEX));
         BMap<BString, Object> fieldAnnotation = (BMap<BString, Object>) annotations.get(annotationKey);
+        if (fieldAnnotation == null) {
+            return false;
+        }
         for (BString key : fieldAnnotation.getKeys()) {
             String keyStr = key.getValue();
             if (keyStr.startsWith(Constants.MODULE_NAME) && keyStr.endsWith(Constants.SEQUENCE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean isFieldAnnotatedWithModuleChoice(BMap<BString, Object> annotations, String fieldName) {
+        BString annotationKey = StringUtils.fromString(Constants.FIELD
+                + fieldName.replaceAll(Constants.RECORD_FIELD_NAME_ESCAPE_CHAR_REGEX, SPECIAL_CHAR_REGEX));
+        BMap<BString, Object> fieldAnnotation = (BMap<BString, Object>) annotations.get(annotationKey);
+        if (fieldAnnotation == null) {
+            return false;
+        }
+        for (BString key : fieldAnnotation.getKeys()) {
+            String keyStr = key.getValue();
+            if (keyStr.startsWith(Constants.MODULE_NAME) && keyStr.endsWith(Constants.CHOICE)) {
                 return true;
             }
         }
@@ -415,6 +449,48 @@ public class SequenceInfo implements ModelGroupInfo {
                 Field field = recordType.getFields().get(fieldName);
                 if (field != null) {
                     collectNestedSequenceElements(TypeUtils.getReferredType(field.getFieldType()), result);
+                }
+            } else if (isFieldAnnotatedWithModuleChoice(annotations, fieldName)) {
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    collectNestedChoiceElements(TypeUtils.getReferredType(field.getFieldType()), result);
+                }
+            } else {
+                result.add(xmlElementName);
+            }
+        }
+    }
+
+    private static void collectNestedChoiceElements(Type type, Set<String> result) {
+        RecordType recordType = null;
+        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            recordType = (RecordType) type;
+        } else if (type.getTag() == TypeTags.ARRAY_TAG) {
+            Type elementType = TypeUtils.getReferredType(((ArrayType) type).getElementType());
+            if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                recordType = (RecordType) elementType;
+            }
+        }
+        if (recordType == null) {
+            return;
+        }
+
+        BMap<BString, Object> annotations = recordType.getAnnotations();
+        HashMap<String, String> elementNameMap = DataUtils.getXmlElementNameMap(recordType);
+        HashMap<String, String> fieldToXmlName = new HashMap<>();
+        elementNameMap.forEach((xmlName, fieldName) -> fieldToXmlName.put(fieldName, xmlName));
+
+        for (String fieldName : recordType.getFields().keySet()) {
+            String xmlElementName = fieldToXmlName.getOrDefault(fieldName, fieldName);
+            if (isFieldAnnotatedWithModuleSequence(annotations, fieldName)) {
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    collectNestedSequenceElements(TypeUtils.getReferredType(field.getFieldType()), result);
+                }
+            } else if (isFieldAnnotatedWithModuleChoice(annotations, fieldName)) {
+                Field field = recordType.getFields().get(fieldName);
+                if (field != null) {
+                    collectNestedChoiceElements(TypeUtils.getReferredType(field.getFieldType()), result);
                 }
             } else {
                 result.add(xmlElementName);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/xsd/SequenceInfo.java
@@ -143,11 +143,21 @@ public class SequenceInfo implements ModelGroupInfo {
 
     @Override
     public void notifyNestedGroupCompleted(String fieldName) {
-        if (!nestedSequenceFieldNames.contains(fieldName)) {
+        String xmlElementName = getXmlElementNameFromFieldName(fieldName);
+        if (!nestedSequenceFieldNames.contains(xmlElementName)) {
             return;
         }
         generateElementOptionalityMapIfNotPresent();
-        checkElementOrderAndUpdateElementOccurences(fieldName);
+        checkElementOrderAndUpdateElementOccurences(xmlElementName);
+    }
+
+    private String getXmlElementNameFromFieldName(String fieldName) {
+        for (Map.Entry<String, String> entry : xmlElementNameMap.entrySet()) {
+            if (entry.getValue().equals(fieldName)) {
+                return entry.getKey();
+            }
+        }
+        return fieldName;
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlParser.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlParser.java
@@ -613,6 +613,10 @@ class XmlParser {
                 }
             }
         }
+        if (!xmlParserData.allowDataProjection) {
+            throw DiagnosticLog.error(DiagnosticErrorCode.UNDEFINED_FIELD, elemQName.getLocalPart(),
+                    xmlParserData.rootRecord);
+        }
     }
 
     private void updateNextRecordForXsd(XmlParserData xmlParserData,

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
@@ -505,7 +505,7 @@ class XmlTraversal {
             RecordType prevRecord = analyzerData.rootRecord;
             analyzerData.rootRecord = elementType;
             traverseXml(xmlItem.getChildrenSeq(), currentFieldType, analyzerData);
-
+            validateModelGroupStackForRootElement(analyzerData);
             initializeAnyAnnotatedArrayFields(analyzerData.currentNode, elementType);
             validateCurrentElementInfo(analyzerData);
             DataUtils.validateRequiredFields(analyzerData, analyzerData.currentNode);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
@@ -1096,6 +1096,10 @@ class XmlTraversal {
                     }
                 }
             }
+            if (!xmlAnalyzerData.allowDataProjection) {
+                throw DiagnosticLog.error(DiagnosticErrorCode.UNDEFINED_FIELD, elemQName.getLocalPart(),
+                        xmlAnalyzerData.rootRecord);
+            }
         }
 
         private void updateNextRecordForXsd(XmlAnalyzerData xmlAnalyzerData, String fieldName,


### PR DESCRIPTION
## Purpose

Fixes: [#8726](https://github.com/ballerina-platform/ballerina-library/issues/8726)

Added the following changes

Previously, when a sequence field contained a nested @Sequence sub record, the parser did not track element order across the XML structure. This caused incorrect validation failures or accepting of invalid element orderings in nested scenarios.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds support for nested sequences in XML value parsing, enabling handling of hierarchical sequence structures and array fields within sequences. It includes implementation changes in the native XML-data library, broad test-suite additions and adjustments, and a package version bump.

Key changes
- Core implementation
  - Extended SequenceInfo to detect, track and manage nested sequence elements, update element ordering and optionality logic, and support per-element max-occurrence (array) handling.
  - Added a default notifyNestedGroupCompleted(String) to ModelGroupInfo and an overriding implementation in SequenceInfo so parent groups are informed when nested groups complete.
  - Introduced helpers to detect array fields and collect nested sequence elements by inspecting annotations and types.
  - Updated XsdUtils to notify parent model groups on nested group completion.
  - XmlTraversal now invokes model-group-stack validation for root elements during record conversion.

- Tests
  - Added extensive tests and public types across the test suite to cover nested sequences, nested arrays, record-array fields, unbounded arrays, multi-level nesting, name-annotation variations, and XML-value variants.
  - Tests include positive round-trip cases and many ordering/presence error scenarios; several assertions were relaxed to accept multiple equivalent error messages where appropriate.

- Versioning and build
  - Bumped package version from 1.6.1 to 1.6.2 and updated native and compiler-plugin dependency references to 1.6.2-SNAPSHOT.

Impact
- Enables more complex XSD-like sequence parsing by allowing sequences to contain nested sequences and array elements, improving validation and round-trip behavior for nested structures.
- Substantially increases test coverage for sequencing and nesting scenarios and adjusts error expectations to match the new validation behavior.

Outstanding tasks
- Link to an issue, update the changelog, add any remaining tests, update the specification, and verify native-image compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->