### PR TITLE
Fix empty/whitespace element silently passed as null for required fields

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.2"
+version = "1.6.3"
 authors = ["Ballerina"]
 keywords = ["xml"]
 repository = "https://github.com/ballerina-platform/module-ballerina-data-xmldata"
@@ -14,8 +14,8 @@ export = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "data-native"
-version = "1.6.2"
-path = "../native/build/libs/data.xmldata-native-1.6.2-SNAPSHOT.jar"
+version = "1.6.3"
+path = "../native/build/libs/data.xmldata-native-1.6.3-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "constraint-compiler-plugin"
 class = "io.ballerina.lib.data.xmldata.compiler.XmldataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/data.xmldata-compiler-plugin-1.6.2-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/data.xmldata-compiler-plugin-1.6.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -39,7 +39,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -39,7 +39,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.12.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -54,7 +54,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.1"
+version = "1.8.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -54,7 +54,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/tests/fromXml_test.bal
+++ b/ballerina/tests/fromXml_test.bal
@@ -3931,3 +3931,58 @@ function testFromXmlWithNamespaceAnnotation() returns error? {
     test:assertTrue(rec2 is error);
     test:assertEquals((<error>rec2).message(), "namespace mismatched for the type: 'RecValue2'");
 }
+
+type PersonWithRequiredLastname record {
+    string? firstname?;
+    string lastname;
+};
+
+@test:Config {
+    groups: ["fromXml", "emptyElement"]
+}
+function testParseAsTypeEmptyElementForNonNilableField() {
+    xml xmlVal = xml `<root><firstname>Julie</firstname><lastname></lastname></root>`;
+    PersonWithRequiredLastname|error result = parseAsType(xmlVal);
+    test:assertTrue(result is error, "Expected an error for empty element assigned to non-nilable field");
+    test:assertEquals((<error>result).message(), "field 'lastname' cannot be converted into the type 'string'");
+}
+
+@test:Config {
+    groups: ["fromXml", "emptyElement"]
+}
+function testParseStringEmptyElementForNonNilableField() {
+    string xmlStr = "<root><firstname>Julie</firstname><lastname></lastname></root>";
+    PersonWithRequiredLastname|error result = parseString(xmlStr);
+    test:assertTrue(result is error, "Expected an error for empty element assigned to non-nilable field");
+    test:assertEquals((<error>result).message(), "field 'lastname' cannot be converted into the type 'string'");
+}
+
+@test:Config {
+    groups: ["fromXml", "emptyElement"]
+}
+function testParseAsTypeWhitespaceOnlyElementForNonNilableField() {
+    xml xmlVal2 = xml `<root><lastname>     </lastname></root>`;
+    PersonWithRequiredLastname|error result = parseAsType(xmlVal2);
+    test:assertTrue(result is error, "Expected an error for whitespace-only element assigned to non-nilable field");
+    test:assertEquals((<error>result).message(), "field 'lastname' cannot be converted into the type 'string'");
+}
+
+@test:Config {
+    groups: ["fromXml", "emptyElement"]
+}
+function testParseStringWhitespaceOnlyElementForNonNilableField() {
+    string xmlStr = "<root><lastname>     </lastname></root>";
+    PersonWithRequiredLastname|error result = parseString(xmlStr);
+    test:assertTrue(result is error, "Expected an error for whitespace-only element assigned to non-nilable field");
+    test:assertEquals((<error>result).message(), "field 'lastname' cannot be converted into the type 'string'");
+}
+
+@test:Config {
+    groups: ["fromXml", "emptyElement"]
+}
+function testParseAsTypeEmptyElementForNilableField() returns error? {
+    xml xmlVal = xml `<root><lastname>Smith</lastname></root>`;
+    PersonWithRequiredLastname result = check parseAsType(xmlVal);
+    test:assertEquals(result.lastname, "Smith");
+    test:assertEquals(result?.firstname, ());
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.6.2-SNAPSHOT
+version=1.6.3-SNAPSHOT
 ballerinaLangVersion=2201.12.9
 
 checkstyleToolVersion=10.12.0

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/DataUtils.java
@@ -482,6 +482,11 @@ public class DataUtils {
         return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.ANYDATA_TAG || typeTag == TypeTags.JSON_TAG;
     }
 
+    public static boolean isNonNilablePrimitive(int typeTag) {
+        return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.INT_TAG || typeTag == TypeTags.FLOAT_TAG
+                || typeTag == TypeTags.DECIMAL_TAG || typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.BYTE_TAG;
+    }
+
     public static BArray createArrayValue(Type type) {
         return switch (type.getTag()) {
             case TypeTags.ARRAY_TAG -> ValueCreator.createArrayValue((ArrayType) type);

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlParser.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlParser.java
@@ -474,6 +474,7 @@ class XmlParser {
 
     @SuppressWarnings("unchecked")
     private void endElement(XMLStreamReader xmlStreamReader, XmlParserData xmlParserData) {
+        Field currentField = xmlParserData.currentField;
         xmlParserData.currentField = null;
         QualifiedName elemQName = getElementName(xmlStreamReader, xmlParserData.useSemanticEquality);
         QualifiedNameMap<Boolean> siblings = xmlParserData.siblings;
@@ -482,6 +483,17 @@ class XmlParser {
         if (siblings.contains(elemQName) && !siblings.get(elemQName)) {
             siblings.put(elemQName, true);
         }
+
+        if (currentField != null) {
+            Type fieldType = TypeUtils.getReferredType(currentField.getFieldType());
+            if (DataUtils.isNonNilablePrimitive(fieldType.getTag())
+                    && !SymbolFlags.isFlagOn(currentField.getFlags(), SymbolFlags.OPTIONAL)
+                    && xmlParserData.currentNode.get(StringUtils.fromString(currentField.getFieldName())) == null) {
+                throw DiagnosticLog.error(DiagnosticErrorCode.FIELD_CANNOT_CAST_INTO_TYPE,
+                        currentField.getFieldName(), currentField.getFieldType());
+            }
+        }
+
         if (parents.isEmpty() || !parents.peek().contains(elemQName)) {
             validateModelGroupStack(xmlParserData, elemQName, false);
             return;

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/xml/XmlTraversal.java
@@ -866,12 +866,19 @@ class XmlTraversal {
             List<BXml> newSequence = filterEmptyValuesOrCommentOrPi(xmlSequence.getChildrenList());
 
             if (newSequence.isEmpty()) {
-                // Special case: initialize empty arrays
                 if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                    // Special case: initialize empty arrays
                     RecordType recordType = (RecordType) type;
                     if (analyzerData.currentNode != null) {
                         initializeEmptySequenceArraysForEmptySequence(
                             (BMap<BString, Object>) analyzerData.currentNode, recordType);
+                    }
+                } else {
+                    Field currentField = analyzerData.currentField;
+                    if (currentField != null && DataUtils.isNonNilablePrimitive(type.getTag())
+                            && !SymbolFlags.isFlagOn(currentField.getFlags(), SymbolFlags.OPTIONAL)) {
+                        throw DiagnosticLog.error(DiagnosticErrorCode.FIELD_CANNOT_CAST_INTO_TYPE,
+                                currentField.getFieldName(), currentField.getFieldType());
                     }
                 }
                 return;


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7416

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed XML-to-record parsing so empty or whitespace-only XML elements are no longer accepted for required primitive fields. The parser now raises an error when a non-nilable primitive field is missing a value, while still preserving existing handling for optional and record types. Added tests to cover empty, whitespace-only, and absent field cases. Also updated package, dependency, and native artifact versions to the newer 1.6.3 snapshot line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->