### PR TITLE
Improve toXml performance and add tree-free toXmlString API

### DIFF
--- a/ballerina/tests/to_xml_string_test.bal
+++ b/ballerina/tests/to_xml_string_test.bal
@@ -229,6 +229,18 @@ isolated function testToXmlStringParityForXsdSequenceArray() returns error? {
 @test:Config {
     groups: ["toXmlString"]
 }
+isolated function testToXmlStringErrorParityForXsdSequenceArrayMaxOccurs() returns error? {
+    XsdSequenceArrayWithXmlValue5 data = {
+        seq_XsdSequenceArrayWithXmlValue5: [
+            {age: 1, salary: 1.0}, {age: 2, salary: 2.0}, {age: 3, salary: 3.0}, {age: 4, salary: 4.0}
+        ]
+    };
+    check assertToXmlStringOutcomeParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
 isolated function testToXmlStringErrorParityForXsdSequenceArray() returns error? {
     XsdSequenceArrayWithXmlValue5 data = {
         seq_XsdSequenceArrayWithXmlValue5: [{age: 1, salary: 1.0}]

--- a/ballerina/tests/to_xml_string_test.bal
+++ b/ballerina/tests/to_xml_string_test.bal
@@ -182,3 +182,219 @@ isolated function testToXmlStringParityWithCustomOptions() returns error? {
     test:assertEquals(stringResult, treeResult.toString(),
             msg = "toXmlString output differs from toXml(...).toString() with custom options");
 }
+
+type ContentOnlyRecord record {|
+    string \#content;
+|};
+
+type RecordWithEmptyNested record {|
+    record {||} inner;
+    string name;
+|};
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForRootTextContent() returns error? {
+    ContentOnlyRecord data = {\#content: "only text"};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForMapOfXml() returns error? {
+    map<xml> data = {"value": xml `<text>1</text>`, "value1": xml `<text>2</text>`};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForAnyAnnotatedField() returns error? {
+    EmployeeWithAny data = {name: "n1", anyElement: <PersonInfo>{age: 3, country: "LK"}};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForXsdSequenceArray() returns error? {
+    XsdSequenceArrayWithXmlValue5 data = {
+        seq_XsdSequenceArrayWithXmlValue5: [{age: 1, salary: 1.0}, {age: 2, salary: 2.0}]
+    };
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringErrorParityForXsdSequenceArray() returns error? {
+    XsdSequenceArrayWithXmlValue5 data = {
+        seq_XsdSequenceArrayWithXmlValue5: [{age: 1, salary: 1.0}]
+    };
+    xml|Error treeResult = toXml(data);
+    string|Error stringResult = toXmlString(data);
+    if treeResult is Error && stringResult is Error {
+        test:assertEquals(stringResult.message(), treeResult.message(),
+                msg = "error messages differ between toXml and toXmlString");
+        return;
+    }
+    test:assertFail("both APIs were expected to return an occurrence-violation error");
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForNonPlainKeyNames() returns error? {
+    map<string> data = {"item.one": "1", "item-two": "2", "_three": "3"};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForArrayWithNilElements() returns error? {
+    record {|string name; (int|())[] values;|} data = {name: "n", values: [1, (), 3]};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForDefaultNamespaceReset() returns error? {
+    Purchased_Bill data = {
+        PurchasedItems: {
+            PLine: [
+                {ItemCode: "223345", Count: 10},
+                {ItemCode: {"discount": "22%", "#content": "200777"}, Count: 7}
+            ]
+        },
+        Address: {StreetAddress: "20, Palm grove, Colombo 3", City: "Colombo", Zip: 300, Country: "LK"},
+        attr: "attr-val"
+    };
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForNestedPrefixedNamespaces() returns error? {
+    Purchased_Bill2 data = {
+        PurchasedItems: {
+            pLine: [
+                {itemCode: "223345", count: 10},
+                {itemCode: {discount: "22%", \#content: "200777"}, count: 7}
+            ]
+        },
+        attr: "attr-val"
+    };
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForEmptyMap() returns error? {
+    map<string> data = {};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForTextOnlyMap() returns error? {
+    map<string> data = {"#content": "top level text"};
+    check assertToXmlStringParity(data);
+    map<string> emptyText = {"#content": ""};
+    check assertToXmlStringParity(emptyText);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForEmptyNestedRecordAndEmptyText() returns error? {
+    RecordWithEmptyNested data = {inner: {}, name: ""};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForXsdChoice() returns error? {
+    XSDChoiceWithXmlValueRecord data = {choice_XSDChoiceWithXmlValueRecord: {age: 3}};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForAnyAnnotatedArray() returns error? {
+    RecordWithOptionalAnyArray data = {
+        id: "1",
+        people: [{age: 1, country: "LK"}, {age: 2, country: "LK"}]
+    };
+    check assertToXmlStringParity(data);
+}
+
+# Asserts that both APIs produce the same outcome — equal text on success, or the
+# same error message on failure — for inputs that may not be convertible.
+#
+# + value - The value to convert through both APIs
+# + return - An error if the outcomes differ
+isolated function assertToXmlStringOutcomeParity(map<anydata> value) returns error? {
+    xml|Error treeResult = toXml(value);
+    string|Error stringResult = toXmlString(value);
+    if treeResult is xml && stringResult is string {
+        test:assertEquals(stringResult, treeResult.toString());
+        return;
+    }
+    if treeResult is Error && stringResult is Error {
+        test:assertEquals(stringResult.message(), treeResult.message());
+        return;
+    }
+    test:assertFail("one API succeeded while the other returned an error");
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringOutcomeParityForUnusualKeyNames() returns error? {
+    check assertToXmlStringOutcomeParity({"1number": "v"});
+    check assertToXmlStringOutcomeParity({"with space": "v"});
+    check assertToXmlStringOutcomeParity({"with\"quote": "v"});
+}
+
+type RecordWithAnydataAnyArray record {|
+    string id;
+    @Any
+    anydata[] anyElement;
+|};
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForAnydataAnyArray() returns error? {
+    RecordWithAnydataAnyArray data = {
+        id: "1",
+        anyElement: [<PersonInfo>{age: 1, country: "LK"}, <AddressInfo>{city: "c", zip: "z"}]
+    };
+    check assertToXmlStringParity(data);
+}
+
+type RecordWithElementOccurrence record {|
+    @Element {
+        minOccurs: 1,
+        maxOccurs: 2
+    }
+    int[] counts;
+|};
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringErrorParityForElementOccurrence() returns error? {
+    check assertToXmlStringOutcomeParity(<RecordWithElementOccurrence>{counts: [1, 2, 3]});
+    check assertToXmlStringOutcomeParity(<RecordWithElementOccurrence>{counts: []});
+    check assertToXmlStringOutcomeParity(<RecordWithElementOccurrence>{counts: [1]});
+}

--- a/ballerina/tests/to_xml_string_test.bal
+++ b/ballerina/tests/to_xml_string_test.bal
@@ -1,0 +1,179 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+type ScaleLine record {|
+    int lineNumber;
+    decimal rate;
+|};
+
+type BatchRecord record {|
+    string material;
+    decimal amount;
+    string currencyCode;
+    ScaleLine[] scales;
+|};
+
+type BatchDocument record {|
+    BatchRecord[] batchRecord;
+|};
+
+type TextFieldRecord record {|
+    string attribute_id;
+    string \#content;
+|};
+
+isolated function assertToXmlStringParity(map<anydata> value) returns error? {
+    xml treeResult = check toXml(value);
+    string stringResult = check toXmlString(value);
+    test:assertEquals(stringResult, treeResult.toString(),
+            msg = "toXmlString output differs from toXml(...).toString()");
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForSimpleRecord() returns error? {
+    SimpleRecord data = {name: "Asha"};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForComplexRecord() returns error? {
+    ComplexRecord data = {name: "Asha", count: 3, description: "first < second & \"third\""};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForNestedUnion() returns error? {
+    RecordWithNestedUnion data = {id: "1", nested: <ComplexRecord>{name: "n", count: 2, description: "d"}};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForDeepUnion() returns error? {
+    RecordWithDeepUnion data = {id: "9", deepField: <Level2Union>{l2Name: "b", inner: {l1Name: "a"}}};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForAnnotatedRecord() returns error? {
+    Customer data = {name: "Asha", age: 10};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForMapValue() returns error? {
+    map<string> data = {a: "1", b: "two", c: "three & four"};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForEmptyRecord() returns error? {
+    record {||} data = {};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForEmptyArrayField() returns error? {
+    RecordWithEmptyArray data = {id: "1", items: []};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForTextFieldAndAttribute() returns error? {
+    TextFieldRecord data = {attribute_id: "id-1", \#content: "text < & > content"};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForBatchDocument() returns error? {
+    BatchRecord[] batchRecords = [];
+    foreach int i in 0 ..< 250 {
+        batchRecords.push({
+            material: string `MAT-${i}`,
+            amount: <decimal>i + 0.09d,
+            currencyCode: "USD",
+            scales: [{lineNumber: 1, rate: 5.1d}, {lineNumber: 2, rate: 9.2d}]
+        });
+    }
+    BatchDocument data = {batchRecord: batchRecords};
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForRestFields() returns error? {
+    record {|string name; anydata...;|} data = {name: "a", "extra": 42, "more": [1, 2, 3]};
+    check assertToXmlStringParity(data);
+}
+
+// Nested namespaces: the child inherits the parent's prefix binding and the
+// grandchild introduces a different default namespace. Asserts in-scope xmlns
+// declarations are suppressed on descendants exactly like the tree serializer does.
+@test:Config {
+    groups: ["toXmlString"]
+}
+function testToXmlStringParityForNestedNamespaces() returns error? {
+    NSRec3 data = {bar: {baz: "2"}};
+    xml treeResult = check toXml(data);
+    string stringResult = check toXmlString(data);
+    test:assertEquals(stringResult, treeResult.toString(),
+            msg = "toXmlString output differs from toXml(...).toString()");
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityForRepeatedAnnotatedRecords() returns error? {
+    map<Customer[]> data = {
+        customer1: [{name: "Asha", age: 10}, {name: "Kalai", age: 10}],
+        customer2: [{name: "Asha", age: 10}]
+    };
+    check assertToXmlStringParity(data);
+}
+
+@test:Config {
+    groups: ["toXmlString"]
+}
+isolated function testToXmlStringParityWithCustomOptions() returns error? {
+    TextFieldRecord data = {attribute_id: "id-1", \#content: "body"};
+    Options options = {attributePrefix: "attribute_", textFieldName: "#content"};
+    xml treeResult = check toXml(data, options);
+    string stringResult = check toXmlString(data, options);
+    test:assertEquals(stringResult, treeResult.toString(),
+            msg = "toXmlString output differs from toXml(...).toString() with custom options");
+}

--- a/ballerina/tests/to_xml_string_test.bal
+++ b/ballerina/tests/to_xml_string_test.bal
@@ -37,6 +37,11 @@ type TextFieldRecord record {|
     string \#content;
 |};
 
+# Asserts that `toXmlString` produces exactly the text `toXml(...).toString()` produces
+# for the given value.
+#
+# + value - The value to convert through both APIs
+# + return - An error if either conversion fails or the outputs differ
 isolated function assertToXmlStringParity(map<anydata> value) returns error? {
     xml treeResult = check toXml(value);
     string stringResult = check toXmlString(value);

--- a/ballerina/xml_api.bal
+++ b/ballerina/xml_api.bal
@@ -237,6 +237,13 @@ public isolated function toXmlString(map<anydata> mapValue, Options options = {}
     return fromRecordToXmlString(jsonValue.toJson(), jsonOptions, inputType);
 }
 
+# Converts a pre-processed record or map representation directly to its XML text,
+# without materializing an intermediate `xml` value tree.
+#
+# + jsonValue - The pre-processed source produced by `getModifiedRecord`
+# + options - The `xmldata:JsonOptions` record for the conversion properties
+# + inputType - The typedesc of the original input, used to read annotations
+# + return - The XML text if the source is successfully converted, or an `xmldata:Error`
 isolated function fromRecordToXmlString(json jsonValue, JsonOptions options, typedesc<anydata> inputType)
     returns string|Error = @java:Method {'class: "io.ballerina.lib.data.xmldata.utils.ToXmlUtils"} external;
 

--- a/ballerina/xml_api.bal
+++ b/ballerina/xml_api.bal
@@ -204,6 +204,42 @@ isolated function convertMapXml(map<xml>|map<xml[]> mapValue) returns xml {
 isolated function getModifiedRecord(map<anydata> mapValue, string textFieldName, typedesc<(map<anydata>|json)> inputType)
     returns json|record {}|Error = @java:Method {'class: "io.ballerina.lib.data.xmldata.utils.DataUtils"} external;
 
+# Converts a `Map` or `Record` representation to its XML text representation.
+#
+# Unlike `toXml`, this does not materialize an intermediate `xml` value tree: the
+# text is composed directly during the traversal, so peak memory stays proportional
+# to the produced text rather than the tree. This makes converting large payloads
+# (for example bulk or batch documents with many repeated records) practical in
+# bounded heaps where `toXml` would require several times the output size.
+#
+# The produced text is the same as `toXml(mapValue, options).toString()`.
+#
+# + mapValue - The `Map` or `Record` representation source to be converted to XML text
+# + options - The `xmldata:Options` record for XML conversion properties
+# + return - XML text representation of the given source if the source is
+# successfully converted or else an `xmldata:Error`
+public isolated function toXmlString(map<anydata> mapValue, Options options = {}) returns string|Error {
+    string textFieldName = options.textFieldName;
+    JsonOptions jsonOptions = {
+        attributePrefix: ATTRIBUTE_PREFIX,
+        arrayEntryTag: EMPTY_STRING,
+        textFieldName,
+        userAttributePrefix: options.attributePrefix
+    };
+    typedesc<(map<anydata>)> inputType = typeof mapValue;
+    json|record {} jsonValue = check getModifiedRecord(mapValue, textFieldName, inputType);
+    if jsonValue is map<xml>|map<xml[]> {
+        return convertMapXml(jsonValue).toString();
+    } else if jsonValue is json[] {
+        jsonOptions.rootTag = jsonValue[1].toString();
+        return fromRecordToXmlString(jsonValue[0], jsonOptions, inputType);
+    }
+    return fromRecordToXmlString(jsonValue.toJson(), jsonOptions, inputType);
+}
+
+isolated function fromRecordToXmlString(json jsonValue, JsonOptions options, typedesc<anydata> inputType)
+    returns string|Error = @java:Method {'class: "io.ballerina.lib.data.xmldata.utils.ToXmlUtils"} external;
+
 # Provides configurations for converting JSON to XML.
 public type JsonOptions record {|
     # The prefix of JSON elements' key which is to be treated as an attribute in the XML representation

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -47,6 +47,8 @@ import org.ballerinalang.langlib.xml.CreateText;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -60,12 +62,44 @@ public class ToXmlUtils {
     private static final BString ATTRIBUTE_PREFIX = StringUtils.fromString("attribute_");
     private static final BString XMLNS = StringUtils.fromString("xmlns");
 
+    /**
+     * Annotation-derived metadata of a record type, computed once per type per conversion.
+     * All contained structures are read-only after construction; they are derived purely
+     * from the type's annotations, so they can be safely shared across all values of the
+     * same type within a single conversion.
+     */
+    private static final class TypeMetadata {
+        final HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap;
+        final HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames;
+        final HashMap<String, ElementInfo> elementInfoRelatedFieldNames;
+        final ArrayList<String> sequenceFieldNames;
+        final HashMap<String, Integer> xsdSequencePriorityOrderWhenInSequence;
+
+        TypeMetadata(Type referredType) {
+            this.elementNamesMap = DataUtils.getElementNameMap(referredType);
+            this.modelGroupRelatedFieldNames = getModelGroupRelatedFieldNames(referredType, elementNamesMap);
+            this.elementInfoRelatedFieldNames = getElementInfoRelatedFieldNames(referredType);
+            this.sequenceFieldNames = getSequenceFieldNames(referredType);
+            this.xsdSequencePriorityOrderWhenInSequence = DataUtils.getXsdSequencePriorityOrder(referredType, true);
+        }
+    }
+
+    private static TypeMetadata getTypeMetadata(IdentityHashMap<Type, TypeMetadata> cache, Type referredType) {
+        TypeMetadata metadata = cache.get(referredType);
+        if (metadata == null) {
+            metadata = new TypeMetadata(referredType);
+            cache.put(referredType, metadata);
+        }
+        return metadata;
+    }
+
     public static Object fromRecordToXml(Object jsonValue, BMap<BString, Object> options, BTypedesc typed) {
         try {
             Type type = typed.getDescribingType();
             Type referredType = TypeUtils.getReferredType(type);
             Object rootTag = options.get(StringUtils.fromString(Constants.ROOT_TAG));
             BMap<BString, BString> allNamespaces = getEmptyStringMap();
+            IdentityHashMap<Type, TypeMetadata> typeMetadataCache = new IdentityHashMap<>();
             BString rootTagBstring =
                     StringUtils.fromString(rootTag == null ? Constants.EMPTY_STRING : rootTag.toString());
 
@@ -75,7 +109,7 @@ public class ToXmlUtils {
                         rootTag == null ? StringUtils.fromString(Constants.ROOT) : rootTagBstring,
                         traverseRecordAndGenerateXml(jsonValue, allNamespaces,
                                 getEmptyStringMap(), options, null, type,
-                                false, false, null, null),
+                                false, false, null, null, typeMetadataCache),
                         allNamespaces, options,
                         getAttributesMap(jsonValue, options, allNamespaces, getEmptyStringMap()));
             }
@@ -95,11 +129,11 @@ public class ToXmlUtils {
 
             BString key = jMap.getKeys()[0];
             String jsonKey = key.getValue();
-            HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = DataUtils.getElementNameMap(referredType);
-            ArrayList<String> sequenceFieldNames = getSequenceFieldNames(referredType);
-            HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames =
-                    getModelGroupRelatedFieldNames(referredType, elementNamesMap);
-            HashMap<String, ElementInfo> elementInfoRelatedFieldNames = getElementInfoRelatedFieldNames(referredType);
+            TypeMetadata typeMetadata = getTypeMetadata(typeMetadataCache, referredType);
+            HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = typeMetadata.elementNamesMap;
+            ArrayList<String> sequenceFieldNames = typeMetadata.sequenceFieldNames;
+            HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames = typeMetadata.modelGroupRelatedFieldNames;
+            HashMap<String, ElementInfo> elementInfoRelatedFieldNames = typeMetadata.elementInfoRelatedFieldNames;
 
             boolean isKeyContainsPrefix = jsonKey.contains(Constants.COLON);
             Object value = ToArray.toArray(jMap).getValues()[0];
@@ -119,7 +153,7 @@ public class ToXmlUtils {
                                 ? StringUtils.fromString(Constants.ROOT) : rootTagBstring, traverseRecordAndGenerateXml(
                                 value, allNamespaces, getEmptyStringMap(), options, key, getChildElementType(
                                         referredType, recordKey), isSequenceField, isSequenceField,
-                                parentModelGroupInfo, elementInfo),
+                                parentModelGroupInfo, elementInfo, typeMetadataCache),
                         allNamespaces, options, getAttributesMap(value, options, allNamespaces, getEmptyStringMap()));
             }
 
@@ -134,7 +168,7 @@ public class ToXmlUtils {
             BXml output = getElementFromRecordMember(key,
                     traverseRecordAndGenerateXml(value, allNamespaces, getEmptyStringMap(), options, null,
                             getChildElementType(referredType, recordKey), isSequenceField,
-                            isSequenceField, parentModelGroupInfo, elementInfo),
+                            isSequenceField, parentModelGroupInfo, elementInfo, typeMetadataCache),
                     allNamespaces, options, getAttributesMap(value, options, allNamespaces, getEmptyStringMap()));
             if (isContainsModelGroup) {
                 output = output.children();
@@ -156,21 +190,36 @@ public class ToXmlUtils {
             BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
             boolean isParentSequence, boolean isParentSequenceArray,
             ModelGroupInfo parentModelGroupInfo, ElementInfo parentElementInfo) throws BError {
+        return traverseRecordAndGenerateXml(jNode, allNamespaces, parentNamespaces, options, keyObj, type,
+                isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
+                new IdentityHashMap<>());
+    }
+
+    private static BXml traverseRecordAndGenerateXml(Object jNode, BMap<BString, BString> allNamespaces,
+            BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
+            boolean isParentSequence, boolean isParentSequenceArray,
+            ModelGroupInfo parentModelGroupInfo, ElementInfo parentElementInfo,
+            IdentityHashMap<Type, TypeMetadata> typeMetadataCache) throws BError {
         BMap<BString, BString> namespacesOfElem;
         BXml xNode = ValueCreator.createXmlValue(Constants.EMPTY_STRING);
         String attributePrefix = options.get(Constants.ATTRIBUTE_PREFIX).toString();
         Type referredType = TypeUtils.getReferredType(type);
-        HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = DataUtils.getElementNameMap(referredType);
-        HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames =
-                getModelGroupRelatedFieldNames(referredType, elementNamesMap);
-        HashMap<String, ElementInfo> elementInfoRelatedFieldNames = getElementInfoRelatedFieldNames(referredType);
-        ArrayList<String> sequenceFieldNames = getSequenceFieldNames(referredType);
+        TypeMetadata typeMetadata = getTypeMetadata(typeMetadataCache, referredType);
+        HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = typeMetadata.elementNamesMap;
+        HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames = typeMetadata.modelGroupRelatedFieldNames;
+        HashMap<String, ElementInfo> elementInfoRelatedFieldNames = typeMetadata.elementInfoRelatedFieldNames;
+        ArrayList<String> sequenceFieldNames = typeMetadata.sequenceFieldNames;
+        // Children are collected in a list and concatenated once at the end: folding with
+        // Concat.concat per child re-copies all previously accumulated children on every
+        // append, which is O(n^2) in the number of children.
+        List<Object> childParts = new ArrayList<>();
         BXml childElement;
 
         if (jNode instanceof BMap jMap) {
             BMap<BString, Object> mapNode = (BMap<BString, Object>) jMap;
             BString[] orderedRecordKeysIfXsdSequencePresent = DataUtils.getOrderedRecordKeysIfXsdSequencePresent(
-                    mapNode, DataUtils.getXsdSequencePriorityOrder(referredType, isParentSequence), referredType);
+                    mapNode, isParentSequence ? typeMetadata.xsdSequencePriorityOrderWhenInSequence
+                            : DataUtils.getXsdSequencePriorityOrder(referredType, false), referredType);
 
             if (parentModelGroupInfo instanceof ChoiceInfo) {
                 validateChoiceFields(parentModelGroupInfo, jMap, elementInfoRelatedFieldNames,
@@ -197,7 +246,7 @@ public class ToXmlUtils {
                 }
 
                 if (jsonKey.equals(options.get(Constants.TEXT_FIELD_NAME).toString())) {
-                    xNode = Concat.concat(xNode, CreateText.createText(StringUtils.fromString(value.toString())));
+                    childParts.add(CreateText.createText(StringUtils.fromString(value.toString())));
                 } else {
                     addNamespaces(allNamespaces, namespacesOfElem);
                     if (value instanceof BArray) {
@@ -259,8 +308,8 @@ public class ToXmlUtils {
                         childElement = traverseRecordAndGenerateXml(value, allNamespaces, namespacesOfElem, options,
                                 keyToPass,
                                 getChildElementType(referredType, recordKey),
-                                isSequenceField, isSequenceField, modelGroupInfo, elementInfo);
-                        xNode = Concat.concat(xNode, childElement);
+                                isSequenceField, isSequenceField, modelGroupInfo, elementInfo, typeMetadataCache);
+                        childParts.add(childElement);
                     } else {
                         BString elementKey = k;
                         if (referredType instanceof RecordType recordType &&
@@ -290,9 +339,10 @@ public class ToXmlUtils {
                         }
                         childElement = getElementFromRecordMember(elementKey, traverseRecordAndGenerateXml(
                                 value, allNamespaces, namespacesOfElem, options, null, getChildElementType(
-                            referredType, recordKey), isSequenceField, isSequenceField, modelGroupInfo, elementInfo),
+                            referredType, recordKey), isSequenceField, isSequenceField, modelGroupInfo, elementInfo,
+                            typeMetadataCache),
                             allNamespaces, options, getAttributesMap(value, options, allNamespaces, parentNamespaces));
-                        xNode = Concat.concat(xNode, !isContainsModelGroup || isParentSequenceArray ? childElement
+                        childParts.add(!isContainsModelGroup || isParentSequenceArray ? childElement
                                 : childElement.children());
                     }
                 }
@@ -338,7 +388,8 @@ public class ToXmlUtils {
                     Type childType = getChildElementType(referredType, null);
                     BXml inner = traverseRecordAndGenerateXml(i, allNamespaces, namespacesOfElem,
                             options, keyObj, childType,
-                            isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo);
+                            isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
+                            typeMetadataCache);
                     String elementTagKey = arrayEntryTagKey;
                     boolean isAnyAnnotatedField = keyObj instanceof BString fieldNameBString && 
                             fieldNameBString.getValue().startsWith("@Any:");
@@ -365,13 +416,17 @@ public class ToXmlUtils {
                     childElement = getElementFromRecordMember(StringUtils.fromString(arrayEntryTagKey),
                         traverseRecordAndGenerateXml(i, allNamespaces, namespacesOfElem,
                                 options, null, getChildElementType(referredType, null),
-                                isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo),
+                                isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
+                                typeMetadataCache),
                         allNamespaces, options, getAttributesMap(i, options, allNamespaces, parentNamespaces));
                 }
-                xNode = Concat.concat(xNode, isParentSequenceArray ? childElement.children() : childElement);
+                childParts.add(isParentSequenceArray ? childElement.children() : childElement);
             }
         } else {
             xNode = CreateText.createText(StringUtils.fromString(StringUtils.getStringValue(jNode)));
+        }
+        if (!childParts.isEmpty()) {
+            xNode = Concat.concat(childParts.toArray());
         }
         return xNode;
     }
@@ -552,19 +607,11 @@ public class ToXmlUtils {
 
     public static boolean isSingleRecordMember(Object node) {
         if (node instanceof BArray arrayNode) {
-            if (arrayNode.getElementType().getTag() == TypeTags.JSON_TAG) {
-                return false;
-            }
+            return arrayNode.getElementType().getTag() != TypeTags.JSON_TAG;
         }
 
-        try {
-            Object convertedValue = ValueUtils
-                    .convert(node, TypeCreator.createMapType(PredefinedTypes.TYPE_ANYDATA));
-            if (convertedValue instanceof BMap mapNode) {
-                return mapNode.size() <= 1;
-            }
-        } catch (BError e) {
-            return true;
+        if (node instanceof BMap mapNode) {
+            return mapNode.size() <= 1;
         }
         return true;
     }
@@ -660,6 +707,11 @@ public class ToXmlUtils {
                                                           BMap<BString, BString> namespaces,
                                                           BMap<BString, BString> parentNamespaces) {
         BMap<BString, BString> attributes = (BMap<BString, BString>) parentNamespaces.copy(new HashMap<>());
+        // Non-map values (scalars, arrays, nil) cannot carry attribute fields; the convert
+        // below would throw for them and the catch would return this same copy.
+        if (!(jsonTree instanceof BMap)) {
+            return attributes;
+        }
         try {
             BMap<BString, Object> attr = (BMap<BString, Object>) ValueUtils.convert(
                     jsonTree, TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
@@ -730,6 +782,11 @@ public class ToXmlUtils {
                                                            BMap<BString, Object> options,
                                                            BMap<BString, BString> parentNamespaces) {
         BMap<BString, BString> namespaces = (BMap<BString, BString>) parentNamespaces.copy(new HashMap<>());
+        // Non-map values (scalars, arrays, nil) cannot carry namespace attribute fields; the
+        // convert below would throw for them and the catch would return this same copy.
+        if (!(jsonTree instanceof BMap)) {
+            return namespaces;
+        }
         try {
             Object jsonTreeObject = ValueUtils.convert(jsonTree, TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
             BMap<BString, Object> attr = (BMap<BString, Object>) jsonTreeObject;

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -25,7 +25,6 @@ import io.ballerina.lib.data.xmldata.utils.xsd.SequenceInfo;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
-import io.ballerina.runtime.api.types.PredefinedTypes;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeTags;
@@ -639,7 +638,7 @@ public class ToXmlUtils {
 
     /**
      * Places already-serialized children inside a serialized empty element, handling both
-     * the self-closing ({@code <tag/>}) and expanded ({@code <tag></tag>}) forms.
+     * the self-closing and the open/close-pair serialized forms.
      *
      * @param emptyElementString the serialized element with no children
      * @param childrenString     the serialized children markup

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -22,7 +22,6 @@ import io.ballerina.lib.data.xmldata.utils.xsd.ChoiceInfo;
 import io.ballerina.lib.data.xmldata.utils.xsd.ElementInfo;
 import io.ballerina.lib.data.xmldata.utils.xsd.ModelGroupInfo;
 import io.ballerina.lib.data.xmldata.utils.xsd.SequenceInfo;
-import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
@@ -117,7 +116,7 @@ public class ToXmlUtils {
             BMap<BString, Object> jMap = null;
             try {
                 jMap = (BMap<BString, Object>) ValueUtils
-                        .convert(jsonValue, TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
+                        .convert(jsonValue, Constants.JSON_MAP_TYPE);
             } catch (BError e) {
                 return jsonValue == null ? ValueCreator.createXmlValue(Constants.EMPTY_STRING)
                         : CreateText.createText(StringUtils.fromString(jsonValue.toString()));
@@ -186,6 +185,439 @@ public class ToXmlUtils {
         return (BMap<BString, BString>) ((BMap<?, ?>) ValueCreator.createMapValue());
     }
 
+    /**
+     * String-producing twin of {@link #fromRecordToXml}. Mirrors the tree-building
+     * conversion step by step but composes the XML text directly, so peak memory is
+     * proportional to the produced text instead of the materialized {@code BXml} tree.
+     * Element open tags (names, attributes, namespace declarations, escaping) are
+     * produced by serializing an empty element through the exact same code path the
+     * tree conversion uses, so the emitted markup stays faithful to {@code toXml}.
+     */
+    public static Object fromRecordToXmlString(Object jsonValue, BMap<BString, Object> options, BTypedesc typed) {
+        try {
+            Type type = typed.getDescribingType();
+            Type referredType = TypeUtils.getReferredType(type);
+            Object rootTag = options.get(StringUtils.fromString(Constants.ROOT_TAG));
+            BMap<BString, BString> allNamespaces = getEmptyStringMap();
+            IdentityHashMap<Type, TypeMetadata> typeMetadataCache = new IdentityHashMap<>();
+            BString rootTagBstring =
+                    StringUtils.fromString(rootTag == null ? Constants.EMPTY_STRING : rootTag.toString());
+
+            if (!isSingleRecordMember(jsonValue)) {
+                BMap<BString, BString> rootDeclarations = getNamespacesMap(jsonValue, options, getEmptyStringMap());
+                addNamespaces(allNamespaces, rootDeclarations);
+                StringBuilder out = new StringBuilder();
+                traverseRecordAndGenerateXmlString(out, jsonValue, allNamespaces,
+                        getEmptyStringMap(), options, null, type, false, false, null, null, typeMetadataCache,
+                        rootDeclarations);
+                insertElementAround(out, 0, elementShellString(
+                        rootTag == null ? StringUtils.fromString(Constants.ROOT) : rootTagBstring,
+                        allNamespaces, options,
+                        getAttributesMap(jsonValue, options, allNamespaces, getEmptyStringMap()),
+                        getEmptyStringMap(), getEmptyStringMap()));
+                return StringUtils.fromString(out.toString());
+            }
+
+            BMap<BString, Object> jMap = null;
+            try {
+                jMap = (BMap<BString, Object>) ValueUtils
+                        .convert(jsonValue, Constants.JSON_MAP_TYPE);
+            } catch (BError e) {
+                return jsonValue == null ? StringUtils.fromString(Constants.EMPTY_STRING)
+                        : StringUtils.fromString(
+                                CreateText.createText(StringUtils.fromString(jsonValue.toString())).toString());
+            }
+
+            if (jMap.isEmpty()) {
+                return StringUtils.fromString(Constants.EMPTY_STRING);
+            }
+
+            BString key = jMap.getKeys()[0];
+            String jsonKey = key.getValue();
+            TypeMetadata typeMetadata = getTypeMetadata(typeMetadataCache, referredType);
+            HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = typeMetadata.elementNamesMap;
+            ArrayList<String> sequenceFieldNames = typeMetadata.sequenceFieldNames;
+            HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames = typeMetadata.modelGroupRelatedFieldNames;
+            HashMap<String, ElementInfo> elementInfoRelatedFieldNames = typeMetadata.elementInfoRelatedFieldNames;
+
+            boolean isKeyContainsPrefix = jsonKey.contains(Constants.COLON);
+            Object value = ToArray.toArray(jMap).getValues()[0];
+            addNamespaces(allNamespaces, getNamespacesMap(value, options, getEmptyStringMap()));
+            String localJsonKeyPart = getElementLocalKeyPart(isKeyContainsPrefix, jsonKey);
+            DataUtils.FieldAnnotationValue jsonKeyFieldAnnotation = getElementNamesMapKey(
+                    isKeyContainsPrefix, jsonKey, allNamespaces, localJsonKeyPart);
+
+            String recordKey = elementNamesMap.getOrDefault(jsonKeyFieldAnnotation, localJsonKeyPart);
+            boolean isSequenceField = sequenceFieldNames.contains(recordKey);
+            boolean isContainsModelGroup = modelGroupRelatedFieldNames.containsKey(recordKey);
+            ModelGroupInfo parentModelGroupInfo = modelGroupRelatedFieldNames.get(recordKey);
+            ElementInfo elementInfo = elementInfoRelatedFieldNames.get(recordKey);
+
+            if (value instanceof BArray) {
+                StringBuilder out = new StringBuilder();
+                traverseRecordAndGenerateXmlString(out, value, allNamespaces, getEmptyStringMap(),
+                        options, key, getChildElementType(referredType, recordKey), isSequenceField, isSequenceField,
+                        parentModelGroupInfo, elementInfo, typeMetadataCache,
+                        getNamespacesMap(value, options, getEmptyStringMap()));
+                insertElementAround(out, 0, elementShellString(rootTag == null
+                                ? StringUtils.fromString(Constants.ROOT) : rootTagBstring,
+                        allNamespaces, options, getAttributesMap(value, options, allNamespaces, getEmptyStringMap()),
+                        getEmptyStringMap(), getEmptyStringMap()));
+                return StringUtils.fromString(out.toString());
+            }
+
+            if (key.equals(options.get(Constants.TEXT_FIELD_NAME))) {
+                if (rootTagBstring.equals(StringUtils.fromString(Constants.EMPTY_STRING))) {
+                    rootTagBstring = StringUtils.fromString(Constants.ROOT);
+                }
+                return StringUtils.fromString(spliceChildrenIntoElement(
+                        CreateElement.createElement(rootTagBstring, getEmptyStringMap(),
+                                ValueCreator.createXmlValue(Constants.EMPTY_STRING)).toString(),
+                        textString(value.toString())));
+            }
+
+            StringBuilder out = new StringBuilder();
+            traverseRecordAndGenerateXmlString(out, value, allNamespaces, getEmptyStringMap(),
+                    options, null, getChildElementType(referredType, recordKey), isSequenceField,
+                    isSequenceField, parentModelGroupInfo, elementInfo, typeMetadataCache,
+                    getNamespacesMap(value, options, getEmptyStringMap()));
+            String shell = elementShellString(key, allNamespaces, options,
+                    getAttributesMap(value, options, allNamespaces, getEmptyStringMap()), getEmptyStringMap(),
+                    getEmptyStringMap());
+            if (!isContainsModelGroup) {
+                insertElementAround(out, 0, shell);
+            }
+            if (rootTag != null) {
+                insertElementAround(out, 0, CreateElement.createElement(rootTagBstring, getEmptyStringMap(),
+                        ValueCreator.createXmlValue(Constants.EMPTY_STRING)).toString());
+            }
+            return StringUtils.fromString(out.toString());
+        } catch (Exception e) {
+            return DiagnosticLog.createXmlError(e.getMessage());
+        }
+    }
+
+    private static void traverseRecordAndGenerateXmlString(StringBuilder out, Object jNode,
+            BMap<BString, BString> allNamespaces,
+            BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
+            boolean isParentSequence, boolean isParentSequenceArray,
+            ModelGroupInfo parentModelGroupInfo, ElementInfo parentElementInfo,
+            IdentityHashMap<Type, TypeMetadata> typeMetadataCache,
+            BMap<BString, BString> rootDeclarations) throws BError {
+        BMap<BString, BString> namespacesOfElem;
+        String attributePrefix = options.get(Constants.ATTRIBUTE_PREFIX).toString();
+        Type referredType = TypeUtils.getReferredType(type);
+        TypeMetadata typeMetadata = getTypeMetadata(typeMetadataCache, referredType);
+        HashMap<DataUtils.FieldAnnotationValue, String> elementNamesMap = typeMetadata.elementNamesMap;
+        HashMap<String, ModelGroupInfo> modelGroupRelatedFieldNames = typeMetadata.modelGroupRelatedFieldNames;
+        HashMap<String, ElementInfo> elementInfoRelatedFieldNames = typeMetadata.elementInfoRelatedFieldNames;
+        ArrayList<String> sequenceFieldNames = typeMetadata.sequenceFieldNames;
+
+        if (jNode instanceof BMap jMap) {
+            BMap<BString, Object> mapNode = (BMap<BString, Object>) jMap;
+            BString[] orderedRecordKeysIfXsdSequencePresent = DataUtils.getOrderedRecordKeysIfXsdSequencePresent(
+                    mapNode, isParentSequence ? typeMetadata.xsdSequencePriorityOrderWhenInSequence
+                            : DataUtils.getXsdSequencePriorityOrder(referredType, false), referredType);
+
+            if (parentModelGroupInfo instanceof ChoiceInfo) {
+                validateChoiceFields(parentModelGroupInfo, jMap, elementInfoRelatedFieldNames,
+                        elementNamesMap, options, parentNamespaces);
+            }
+
+            for (BString k : orderedRecordKeysIfXsdSequencePresent) {
+                Object value = mapNode.get(k);
+                String jsonKey = k.getValue().trim();
+                boolean isKeyContainsPrefix = jsonKey.contains(Constants.COLON);
+                namespacesOfElem = getNamespacesMap(value, options, parentNamespaces);
+                String localJsonKeyPart = getElementLocalKeyPart(isKeyContainsPrefix, jsonKey);
+                DataUtils.FieldAnnotationValue jsonKeyFieldAnnotation = getElementNamesMapKey(
+                        isKeyContainsPrefix, jsonKey, namespacesOfElem, localJsonKeyPart);
+
+                String recordKey = elementNamesMap.getOrDefault(jsonKeyFieldAnnotation, localJsonKeyPart);
+                boolean isContainsModelGroup = modelGroupRelatedFieldNames.containsKey(recordKey);
+                ModelGroupInfo modelGroupInfo = modelGroupRelatedFieldNames.get(recordKey);
+                ElementInfo elementInfo = elementInfoRelatedFieldNames.get(recordKey);
+                boolean isSequenceField = sequenceFieldNames.contains(recordKey);
+
+                if (jsonKey.startsWith(attributePrefix)) {
+                    continue;
+                }
+
+                if (jsonKey.equals(options.get(Constants.TEXT_FIELD_NAME).toString())) {
+                    out.append(textString(value.toString()));
+                } else {
+                    addNamespaces(allNamespaces, namespacesOfElem);
+                    if (value instanceof BArray) {
+                        BString keyToPass = isAnyArrayFieldKey(referredType, recordKey, value)
+                                ? StringUtils.fromString("@Any:" + k.getValue()) : k;
+                        traverseRecordAndGenerateXmlString(out, value, allNamespaces, namespacesOfElem,
+                                options, keyToPass, getChildElementType(referredType, recordKey),
+                                isSequenceField, isSequenceField, modelGroupInfo, elementInfo, typeMetadataCache,
+                                rootDeclarations);
+                    } else {
+                        BString elementKey = resolveAnyAnnotatedElementKey(referredType, recordKey, k);
+                        int mark = out.length();
+                        traverseRecordAndGenerateXmlString(out, value, allNamespaces, namespacesOfElem,
+                                options, null, getChildElementType(referredType, recordKey), isSequenceField,
+                                isSequenceField, modelGroupInfo, elementInfo, typeMetadataCache, rootDeclarations);
+                        String shell = elementShellString(elementKey, allNamespaces, options,
+                                getAttributesMap(value, options, allNamespaces, parentNamespaces), parentNamespaces,
+                                rootDeclarations);
+                        if (!isContainsModelGroup || isParentSequenceArray) {
+                            insertElementAround(out, mark, shell);
+                        }
+                    }
+                }
+            }
+        } else if (jNode instanceof BArray arrayNode) {
+            int size = arrayNode.size();
+            if (isParentSequenceArray && parentModelGroupInfo != null && parentModelGroupInfo instanceof SequenceInfo) {
+                if (size < parentModelGroupInfo.getMinOccurs()) {
+                    throw DiagnosticLog.error(DiagnosticErrorCode.ELEMENT_OCCURS_LESS_THAN_MIN_REQUIRED_TIMES,
+                            parentModelGroupInfo.getFieldName());
+                }
+
+                if (size > parentModelGroupInfo.getMaxOccurs()) {
+                    throw DiagnosticLog.error(DiagnosticErrorCode.ELEMENT_OCCURS_MORE_THAN_MAX_ALLOWED_TIMES,
+                            parentModelGroupInfo.getFieldName());
+                }
+            } else {
+                if (parentElementInfo != null && size > parentElementInfo.maxOccurs) {
+                    throw DiagnosticLog.error(DiagnosticErrorCode.ELEMENT_OCCURS_MORE_THAN_MAX_ALLOWED_TIMES,
+                            parentElementInfo.fieldName);
+                }
+
+                if (parentElementInfo != null && size < parentElementInfo.minOccurs) {
+                    throw DiagnosticLog.error(DiagnosticErrorCode.ELEMENT_OCCURS_LESS_THAN_MIN_REQUIRED_TIMES,
+                            parentElementInfo.fieldName);
+                }
+            }
+
+            for (Object i : arrayNode.getValues()) {
+                if (i == null) {
+                    continue;
+                }
+                String arrayEntryTagKey = Constants.EMPTY_STRING;
+                if (keyObj instanceof BString key) {
+                    arrayEntryTagKey = key.getValue();
+                } else if (!options.get(Constants.ARRAY_ENTRY_TAG).toString().isEmpty()) {
+                    arrayEntryTagKey = options.get(Constants.ARRAY_ENTRY_TAG).toString();
+                }
+
+                namespacesOfElem = getNamespacesMap(i, options, parentNamespaces);
+                addNamespaces(allNamespaces, namespacesOfElem);
+                int mark = out.length();
+                String shell;
+                if (options.get(Constants.ARRAY_ENTRY_TAG).toString().isEmpty()) {
+                    Type childType = getChildElementType(referredType, null);
+                    traverseRecordAndGenerateXmlString(out, i, allNamespaces, namespacesOfElem,
+                            options, keyObj, childType,
+                            isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
+                            typeMetadataCache, rootDeclarations);
+                    String elementTagKey = arrayEntryTagKey;
+                    boolean isAnyAnnotatedField = keyObj instanceof BString fieldNameBString &&
+                            fieldNameBString.getValue().startsWith("@Any:");
+
+                    if (isAnyAnnotatedField && i instanceof BMap) {
+                        Type elementValueType = TypeUtils.getType(i);
+                        Type referredElementType = TypeUtils.getReferredType(elementValueType);
+                        if (referredElementType instanceof RecordType recordValueType) {
+                            elementTagKey = getRecordTypeName(recordValueType);
+                        } else {
+                            // Fallback to declared child type if runtime type is not a RecordType
+                            Type referredChildType = TypeUtils.getReferredType(childType);
+                            if (referredChildType instanceof RecordType recordChildType) {
+                                elementTagKey = getRecordTypeName(recordChildType);
+                            }
+                        }
+                    }
+                    shell = elementShellString(StringUtils.fromString(elementTagKey),
+                            allNamespaces, options, getAttributesMap(i, options, allNamespaces, parentNamespaces),
+                            parentNamespaces, rootDeclarations);
+                } else {
+                    traverseRecordAndGenerateXmlString(out, i, allNamespaces, namespacesOfElem,
+                            options, null, getChildElementType(referredType, null),
+                            isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
+                            typeMetadataCache, rootDeclarations);
+                    shell = elementShellString(StringUtils.fromString(arrayEntryTagKey),
+                            allNamespaces, options, getAttributesMap(i, options, allNamespaces, parentNamespaces),
+                            parentNamespaces, rootDeclarations);
+                }
+                if (!isParentSequenceArray) {
+                    insertElementAround(out, mark, shell);
+                }
+            }
+        } else {
+            out.append(textString(StringUtils.getStringValue(jNode)));
+        }
+    }
+
+    /**
+     * Builds an element's serialized "shell" — the element with no children — through the
+     * exact name/attribute/namespace logic of {@link #getElementFromRecordMember}. The
+     * already-serialized children are later placed inside it by
+     * {@link #insertElementAround}.
+     */
+    private static String elementShellString(BString name, BMap<BString, BString> namespaces,
+            BMap<BString, Object> options, BMap<BString, BString> attributes,
+            BMap<BString, BString> nearestScopeNamespaces, BMap<BString, BString> rootScopeNamespaces) {
+        // Fast path for the common case: no attributes, no prefix, plain name, no name
+        // rewriting configured. The full path builds an XML element value and runs the
+        // serializer, which allocates heavily (element, attribute map, type objects) —
+        // for an attribute-less simple name the serialized form is fixed.
+        String nameStr = name.getValue();
+        if (attributes.isEmpty() && isPlainElementName(nameStr)
+                && options.get(Constants.USER_ATTRIBUTE_PREFIX).toString().isEmpty()
+                && !nameStr.startsWith(options.get(Constants.ATTRIBUTE_PREFIX).toString())) {
+            return "<" + nameStr + "/>";
+        }
+        BXml emptyElement = getElementFromRecordMember(name, ValueCreator.createXmlValue(Constants.EMPTY_STRING),
+                namespaces, options, attributes);
+        return serializeWithinScope(emptyElement, nearestScopeNamespaces, rootScopeNamespaces);
+    }
+
+    private static boolean isPlainElementName(String name) {
+        if (name.isEmpty()) {
+            return false;
+        }
+        char first = name.charAt(0);
+        if (!(Character.isLetter(first) || first == '_')) {
+            return false;
+        }
+        for (int i = 1; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (!(Character.isLetterOrDigit(c) || c == '_' || c == '.' || c == '-')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Wraps the builder content from {@code mark} onward in the given element shell,
+     * inserting the open tag at {@code mark} and appending the close tag — so children
+     * are written once into a single shared builder instead of being copied at every
+     * nesting level.
+     */
+    private static void insertElementAround(StringBuilder out, int mark, String shellString) {
+        if (out.length() == mark) {
+            out.append(shellString);
+            return;
+        }
+        if (shellString.endsWith("/>")) {
+            int nameEnd = 1;
+            while (nameEnd < shellString.length()) {
+                char c = shellString.charAt(nameEnd);
+                if (c == ' ' || c == '/' || c == '>' || c == '\t' || c == '\n' || c == '\r') {
+                    break;
+                }
+                nameEnd++;
+            }
+            String qualifiedName = shellString.substring(1, nameEnd);
+            out.insert(mark, ">").insert(mark, shellString.substring(0, shellString.length() - 2));
+            out.append("</").append(qualifiedName).append(">");
+            return;
+        }
+        // <tag ...></tag> form: '<' never occurs unescaped inside attribute values, so the
+        // first "></" is the boundary between the open and close tags.
+        int boundary = shellString.indexOf("></");
+        if (boundary == -1) {
+            throw new IllegalStateException("unexpected empty element serialization: " + shellString);
+        }
+        out.insert(mark, shellString.substring(0, boundary + 1));
+        out.append(shellString.substring(boundary + 1));
+    }
+
+    /**
+     * Serializes an element as it would appear under ancestors that declare the given
+     * namespaces: the element is placed inside a synthetic wrapper element carrying the
+     * in-scope declarations, so the runtime serializer itself suppresses duplicate xmlns
+     * attributes — exactly as it does when a whole tree is serialized — and the wrapper
+     * tags are then stripped. The nearest scope wins over the root element's declarations.
+     */
+    private static String serializeWithinScope(BXml element, BMap<BString, BString> nearestScope,
+            BMap<BString, BString> rootScope) {
+        if (nearestScope.isEmpty() && rootScope.isEmpty()) {
+            return element.toString();
+        }
+        BMap<BString, BString> scopeDeclarations = getEmptyStringMap();
+        putScopeDeclarations(scopeDeclarations, rootScope);
+        putScopeDeclarations(scopeDeclarations, nearestScope);
+        BXml wrapper = CreateElement.createElement(StringUtils.fromString("w"), scopeDeclarations, element);
+        String serialized = wrapper.toString();
+        int openTagEnd = serialized.indexOf('>');
+        return serialized.substring(openTagEnd + 1, serialized.length() - "</w>".length());
+    }
+
+    /**
+     * Copies namespace declarations into an attribute map for element creation. The
+     * default namespace is keyed as {@code {xmlns-uri}} (empty local part) in scope maps
+     * and must be stored under the plain {@code xmlns} attribute name, as
+     * {@link #getElementFromRecordMember} does for regular elements.
+     */
+    private static void putScopeDeclarations(BMap<BString, BString> target, BMap<BString, BString> scope) {
+        String xmlnsNameUri = getXmlnsNameUrI();
+        for (Map.Entry<BString, BString> declaration : scope.entrySet()) {
+            BString declarationKey = declaration.getKey();
+            target.put(declarationKey.getValue().equals(xmlnsNameUri) ? XMLNS : declarationKey,
+                    declaration.getValue());
+        }
+    }
+
+    /**
+     * Serializes text exactly as it appears inside an element in a serialized tree
+     * (standalone text serialization escapes additional characters, e.g. {@code >}),
+     * by wrapping it in a single-character element and stripping the wrapper tags.
+     */
+    private static String textString(String textValue) {
+        if (textValue.isEmpty()) {
+            return Constants.EMPTY_STRING;
+        }
+        // Fast path: text without characters the serializer escapes (or may escape) is
+        // emitted verbatim. Anything else takes the exact serializer round trip.
+        boolean needsEscaping = false;
+        for (int i = 0; i < textValue.length(); i++) {
+            char c = textValue.charAt(i);
+            if (c == '&' || c == '<' || c == '>' || c == '\r' || c == '\n' || c == '"' || c == '\'') {
+                needsEscaping = true;
+                break;
+            }
+        }
+        if (!needsEscaping) {
+            return textValue;
+        }
+        String wrapped = CreateElement.createElement(StringUtils.fromString("x"), getEmptyStringMap(),
+                CreateText.createText(StringUtils.fromString(textValue))).toString();
+        return wrapped.substring(3, wrapped.length() - 4);
+    }
+
+    private static String spliceChildrenIntoElement(String emptyElementString, String childrenString) {
+        if (childrenString.isEmpty()) {
+            return emptyElementString;
+        }
+        if (emptyElementString.endsWith("/>")) {
+            int nameEnd = 1;
+            while (nameEnd < emptyElementString.length()) {
+                char c = emptyElementString.charAt(nameEnd);
+                if (c == ' ' || c == '/' || c == '>' || c == '\t' || c == '\n' || c == '\r') {
+                    break;
+                }
+                nameEnd++;
+            }
+            String qualifiedName = emptyElementString.substring(1, nameEnd);
+            return emptyElementString.substring(0, emptyElementString.length() - 2) + ">" + childrenString
+                    + "</" + qualifiedName + ">";
+        }
+        // <tag ...></tag> form: '<' never occurs unescaped inside attribute values, so the
+        // first "></" is the boundary between the open and close tags.
+        int boundary = emptyElementString.indexOf("></");
+        if (boundary == -1) {
+            throw new IllegalStateException("unexpected empty element serialization: " + emptyElementString);
+        }
+        return emptyElementString.substring(0, boundary + 1) + childrenString
+                + emptyElementString.substring(boundary + 1);
+    }
+
     public static BXml traverseRecordAndGenerateXml(Object jNode, BMap<BString, BString> allNamespaces,
             BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
             boolean isParentSequence, boolean isParentSequenceArray,
@@ -250,93 +682,16 @@ public class ToXmlUtils {
                 } else {
                     addNamespaces(allNamespaces, namespacesOfElem);
                     if (value instanceof BArray) {
-                        boolean isAnyArrayField = false;
-                        if (DataUtils.isFieldAnnotatedWithAny(referredType, recordKey)) {
-                            Type childElementType = getChildElementType(referredType, recordKey);
-                            Type referredChildType = TypeUtils.getReferredType(childElementType);
-                            if (referredChildType.getTag() == TypeTags.ARRAY_TAG) {
-                                ArrayType arrayType = (ArrayType) referredChildType;
-                                Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
-                                if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
-                                    isAnyArrayField = true;
-                                } else if (elementType.getTag() == TypeTags.ANYDATA_TAG) {
-                                    BArray array = (BArray) value;
-                                    for (int i = 0; i < array.size(); i++) {
-                                        Object element = array.get(i);
-                                        if (element != null) {
-                                            Type actualType = TypeUtils.getType(element);
-                                            if (TypeUtils.getReferredType(actualType).getTag() ==
-                                                    TypeTags.RECORD_TYPE_TAG) {
-                                                isAnyArrayField = true;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                            } else if (referredChildType.getTag() == TypeTags.UNION_TAG) {
-                                UnionType unionType = (UnionType) referredChildType;
-                                for (Type memberType : unionType.getMemberTypes()) {
-                                    Type referredMemberType = TypeUtils.getReferredType(memberType);
-                                    if (referredMemberType.getTag() == TypeTags.ARRAY_TAG) {
-                                        ArrayType arrayType = (ArrayType) referredMemberType;
-                                        Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
-                                        if (elementType.getTag() == TypeTags.ANYDATA_TAG &&
-                                                TypeUtils.getType(value).getTag() == TypeTags.ARRAY_TAG) {
-                                            BArray array = (BArray) value;
-                                            if (array.size() > 0) {
-                                                for (int i = 0; i < array.size(); i++) {
-                                                    Object element = array.get(i);
-                                                    if (element != null) {
-                                                        Type actualType = TypeUtils.getType(element);
-                                                        if (TypeUtils.getReferredType(actualType).getTag() ==
-                                                                TypeTags.RECORD_TYPE_TAG) {
-                                                            isAnyArrayField = true;
-                                                            break;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        BString keyToPass = isAnyArrayField ? 
-                                StringUtils.fromString("@Any:" + k.getValue()) : k;
-                        
+                        BString keyToPass = isAnyArrayFieldKey(referredType, recordKey, value)
+                                ? StringUtils.fromString("@Any:" + k.getValue()) : k;
+
                         childElement = traverseRecordAndGenerateXml(value, allNamespaces, namespacesOfElem, options,
                                 keyToPass,
                                 getChildElementType(referredType, recordKey),
                                 isSequenceField, isSequenceField, modelGroupInfo, elementInfo, typeMetadataCache);
                         childParts.add(childElement);
                     } else {
-                        BString elementKey = k;
-                        if (referredType instanceof RecordType recordType &&
-                            DataUtils.isFieldAnnotatedWithAny(recordType, recordKey)) {
-                            Type valueType = TypeUtils.getType(value);
-                            Type referredValueType = TypeUtils.getReferredType(valueType);
-                            RecordType recordValueType = null;
-
-                            Type childType = getChildElementType(referredType, recordKey);
-                                Type referredChildType = TypeUtils.getReferredType(childType);
-                                if (referredChildType instanceof RecordType) {
-                                    recordValueType = (RecordType) referredChildType;
-                                } else if (referredChildType instanceof UnionType unionType) {
-                                    for (Type memberType : unionType.getMemberTypes()) {
-                                        Type referredMemberType = TypeUtils.getReferredType(memberType);
-                                        if (referredMemberType instanceof RecordType) {
-                                            recordValueType = (RecordType) referredMemberType;
-                                            break;
-                                        }
-                                    }
-                                }
-
-                            if (recordValueType != null) {
-                                String typeName = getRecordTypeName(recordValueType);
-                                elementKey = StringUtils.fromString(typeName);
-                            }
-                        }
+                        BString elementKey = resolveAnyAnnotatedElementKey(referredType, recordKey, k);
                         childElement = getElementFromRecordMember(elementKey, traverseRecordAndGenerateXml(
                                 value, allNamespaces, namespacesOfElem, options, null, getChildElementType(
                             referredType, recordKey), isSequenceField, isSequenceField, modelGroupInfo, elementInfo,
@@ -429,6 +784,86 @@ public class ToXmlUtils {
             xNode = Concat.concat(childParts.toArray());
         }
         return xNode;
+    }
+
+    private static boolean isAnyArrayFieldKey(Type referredType, String recordKey, Object value) {
+        if (!DataUtils.isFieldAnnotatedWithAny(referredType, recordKey)) {
+            return false;
+        }
+        Type childElementType = getChildElementType(referredType, recordKey);
+        Type referredChildType = TypeUtils.getReferredType(childElementType);
+        if (referredChildType.getTag() == TypeTags.ARRAY_TAG) {
+            ArrayType arrayType = (ArrayType) referredChildType;
+            Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
+            if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                return true;
+            } else if (elementType.getTag() == TypeTags.ANYDATA_TAG) {
+                BArray array = (BArray) value;
+                for (int i = 0; i < array.size(); i++) {
+                    Object element = array.get(i);
+                    if (element != null) {
+                        Type actualType = TypeUtils.getType(element);
+                        if (TypeUtils.getReferredType(actualType).getTag() == TypeTags.RECORD_TYPE_TAG) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        } else if (referredChildType.getTag() == TypeTags.UNION_TAG) {
+            UnionType unionType = (UnionType) referredChildType;
+            for (Type memberType : unionType.getMemberTypes()) {
+                Type referredMemberType = TypeUtils.getReferredType(memberType);
+                if (referredMemberType.getTag() == TypeTags.ARRAY_TAG) {
+                    ArrayType arrayType = (ArrayType) referredMemberType;
+                    Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
+                    if (elementType.getTag() == TypeTags.ANYDATA_TAG &&
+                            TypeUtils.getType(value).getTag() == TypeTags.ARRAY_TAG) {
+                        BArray array = (BArray) value;
+                        if (array.size() > 0) {
+                            for (int i = 0; i < array.size(); i++) {
+                                Object element = array.get(i);
+                                if (element != null) {
+                                    Type actualType = TypeUtils.getType(element);
+                                    if (TypeUtils.getReferredType(actualType).getTag() == TypeTags.RECORD_TYPE_TAG) {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static BString resolveAnyAnnotatedElementKey(Type referredType, String recordKey, BString k) {
+        BString elementKey = k;
+        if (referredType instanceof RecordType recordType &&
+                DataUtils.isFieldAnnotatedWithAny(recordType, recordKey)) {
+            RecordType recordValueType = null;
+
+            Type childType = getChildElementType(referredType, recordKey);
+            Type referredChildType = TypeUtils.getReferredType(childType);
+            if (referredChildType instanceof RecordType) {
+                recordValueType = (RecordType) referredChildType;
+            } else if (referredChildType instanceof UnionType unionType) {
+                for (Type memberType : unionType.getMemberTypes()) {
+                    Type referredMemberType = TypeUtils.getReferredType(memberType);
+                    if (referredMemberType instanceof RecordType) {
+                        recordValueType = (RecordType) referredMemberType;
+                        break;
+                    }
+                }
+            }
+
+            if (recordValueType != null) {
+                String typeName = getRecordTypeName(recordValueType);
+                elementKey = StringUtils.fromString(typeName);
+            }
+        }
+        return elementKey;
     }
 
     private static void validateChoiceFields(ModelGroupInfo parentModelGroupInfo, BMap jMap,
@@ -607,6 +1042,10 @@ public class ToXmlUtils {
 
     public static boolean isSingleRecordMember(Object node) {
         if (node instanceof BArray arrayNode) {
+            // Intentionally compares the declared element type without resolving type
+            // references, matching the pre-optimization behavior exactly: previously a
+            // named-json-alias array failed the JSON_TAG check and then threw inside
+            // ValueUtils.convert, which also resulted in true.
             return arrayNode.getElementType().getTag() != TypeTags.JSON_TAG;
         }
 
@@ -714,7 +1153,7 @@ public class ToXmlUtils {
         }
         try {
             BMap<BString, Object> attr = (BMap<BString, Object>) ValueUtils.convert(
-                    jsonTree, TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
+                    jsonTree, Constants.JSON_MAP_TYPE);
 
             String attributePrefix = options.get(Constants.ATTRIBUTE_PREFIX).toString();
             for (Map.Entry<BString, Object> entry : attr.entrySet()) {
@@ -788,7 +1227,7 @@ public class ToXmlUtils {
             return namespaces;
         }
         try {
-            Object jsonTreeObject = ValueUtils.convert(jsonTree, TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
+            Object jsonTreeObject = ValueUtils.convert(jsonTree, Constants.JSON_MAP_TYPE);
             BMap<BString, Object> attr = (BMap<BString, Object>) jsonTreeObject;
             String attributePrefix = options.get(Constants.ATTRIBUTE_PREFIX).toString();
 

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -234,15 +234,10 @@ public class ToXmlUtils {
                 return StringUtils.fromString(out.toString());
             }
 
-            BMap<BString, Object> jMap = null;
-            try {
-                jMap = (BMap<BString, Object>) ValueUtils
-                        .convert(jsonValue, Constants.JSON_MAP_TYPE);
-            } catch (BError e) {
-                return jsonValue == null ? StringUtils.fromString(Constants.EMPTY_STRING)
-                        : StringUtils.fromString(
-                                CreateText.createText(StringUtils.fromString(jsonValue.toString())).toString());
-            }
+            // Unlike the tree twin, jsonValue is always a map here: toXmlString routes
+            // record-typed input through the json[] branch and map input through toJson().
+            BMap<BString, Object> jMap = (BMap<BString, Object>) ValueUtils
+                    .convert(jsonValue, Constants.JSON_MAP_TYPE);
 
             if (jMap.isEmpty()) {
                 return StringUtils.fromString(Constants.EMPTY_STRING);
@@ -513,20 +508,15 @@ public class ToXmlUtils {
      * @return true if the serialized form of the name is the name itself
      */
     private static boolean isPlainElementName(String name) {
-        if (name.isEmpty()) {
-            return false;
-        }
-        char first = name.charAt(0);
-        if (!(Character.isLetter(first) || first == '_')) {
-            return false;
-        }
-        for (int i = 1; i < name.length(); i++) {
+        for (int i = 0; i < name.length(); i++) {
             char c = name.charAt(i);
-            if (!(Character.isLetterOrDigit(c) || c == '_' || c == '.' || c == '-')) {
+            boolean valid = i == 0 ? Character.isLetter(c) || c == '_'
+                    : Character.isLetterOrDigit(c) || c == '_' || c == '.' || c == '-';
+            if (!valid) {
                 return false;
             }
         }
-        return true;
+        return !name.isEmpty();
     }
 
     /**
@@ -655,32 +645,6 @@ public class ToXmlUtils {
         }
         return emptyElementString.substring(0, boundary + 1) + childrenString
                 + emptyElementString.substring(boundary + 1);
-    }
-
-    /**
-     * Converts a value's children to XML nodes. Kept for API compatibility: delegates to
-     * the cached variant with a fresh per-call type metadata cache.
-     *
-     * @param jNode             the value whose children are being converted
-     * @param allNamespaces     all namespace declarations seen so far (mutated)
-     * @param parentNamespaces  namespace declarations in scope from the parent chain
-     * @param options           the JSON-to-XML conversion options
-     * @param keyObj            the field key for array traversals, or {@code null}
-     * @param type              the declared type of {@code jNode}
-     * @param isParentSequence  whether the parent field carries an XSD sequence annotation
-     * @param isParentSequenceArray whether the parent is a sequence-annotated array
-     * @param parentModelGroupInfo  the parent's XSD model group metadata, if any
-     * @param parentElementInfo the parent's XSD element metadata, if any
-     * @return the children of the element being built, as an XML sequence
-     * @throws BError on XSD occurrence violations
-     */
-    public static BXml traverseRecordAndGenerateXml(Object jNode, BMap<BString, BString> allNamespaces,
-            BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
-            boolean isParentSequence, boolean isParentSequenceArray,
-            ModelGroupInfo parentModelGroupInfo, ElementInfo parentElementInfo) throws BError {
-        return traverseRecordAndGenerateXml(jNode, allNamespaces, parentNamespaces, options, keyObj, type,
-                isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
-                new IdentityHashMap<>());
     }
 
     private static BXml traverseRecordAndGenerateXml(Object jNode, BMap<BString, BString> allNamespaces,

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -83,6 +83,14 @@ public class ToXmlUtils {
         }
     }
 
+    /**
+     * Returns the annotation-derived metadata for a type, computing it on first use and
+     * reusing it for every subsequent value of the same type within one conversion.
+     *
+     * @param cache        the per-conversion metadata cache, keyed by type identity
+     * @param referredType the referred (dereferenced) type to look up
+     * @return the cached or freshly computed metadata for the type
+     */
     private static TypeMetadata getTypeMetadata(IdentityHashMap<Type, TypeMetadata> cache, Type referredType) {
         TypeMetadata metadata = cache.get(referredType);
         if (metadata == null) {
@@ -92,6 +100,15 @@ public class ToXmlUtils {
         return metadata;
     }
 
+    /**
+     * Converts a record or map value to an {@code xml} value. This is the native
+     * implementation behind {@code xmldata:toXml}.
+     *
+     * @param jsonValue the value to convert, already pre-processed by {@code getModifiedRecord}
+     * @param options   the JSON-to-XML conversion options
+     * @param typed     the typedesc of the original input, used to read annotations
+     * @return the converted {@code BXml} value, or a {@code BError} on failure
+     */
     public static Object fromRecordToXml(Object jsonValue, BMap<BString, Object> options, BTypedesc typed) {
         try {
             Type type = typed.getDescribingType();
@@ -297,6 +314,27 @@ public class ToXmlUtils {
         }
     }
 
+    /**
+     * String-producing twin of {@link #traverseRecordAndGenerateXml}: walks the value in
+     * the same order and writes the children's markup directly into the shared builder.
+     * Elements are wrapped in place via {@link #insertElementAround}, so no intermediate
+     * {@code BXml} nodes or per-level string copies are created.
+     *
+     * @param out               the shared builder the markup is written into
+     * @param jNode             the value whose children are being converted
+     * @param allNamespaces     all namespace declarations seen so far (mutated)
+     * @param parentNamespaces  namespace declarations in scope from the parent chain
+     * @param options           the JSON-to-XML conversion options
+     * @param keyObj            the field key for array traversals, or {@code null}
+     * @param type              the declared type of {@code jNode}
+     * @param isParentSequence  whether the parent field carries an XSD sequence annotation
+     * @param isParentSequenceArray whether the parent is a sequence-annotated array
+     * @param parentModelGroupInfo  the parent's XSD model group metadata, if any
+     * @param parentElementInfo the parent's XSD element metadata, if any
+     * @param typeMetadataCache the per-conversion type metadata cache
+     * @param rootDeclarations  namespace declarations emitted on the root element
+     * @throws BError on XSD occurrence violations
+     */
     private static void traverseRecordAndGenerateXmlString(StringBuilder out, Object jNode,
             BMap<BString, BString> allNamespaces,
             BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
@@ -476,6 +514,14 @@ public class ToXmlUtils {
         return serializeWithinScope(emptyElement, nearestScopeNamespaces, rootScopeNamespaces);
     }
 
+    /**
+     * Reports whether an element name is emitted verbatim by the serializer: a letter or
+     * underscore followed by letters, digits, {@code _}, {@code .} or {@code -}. Names
+     * outside this conservative subset take the full element-construction path.
+     *
+     * @param name the element name to check
+     * @return true if the serialized form of the name is the name itself
+     */
     private static boolean isPlainElementName(String name) {
         if (name.isEmpty()) {
             return false;
@@ -591,6 +637,14 @@ public class ToXmlUtils {
         return wrapped.substring(3, wrapped.length() - 4);
     }
 
+    /**
+     * Places already-serialized children inside a serialized empty element, handling both
+     * the self-closing ({@code <tag/>}) and expanded ({@code <tag></tag>}) forms.
+     *
+     * @param emptyElementString the serialized element with no children
+     * @param childrenString     the serialized children markup
+     * @return the serialized element containing the children
+     */
     private static String spliceChildrenIntoElement(String emptyElementString, String childrenString) {
         if (childrenString.isEmpty()) {
             return emptyElementString;
@@ -618,6 +672,23 @@ public class ToXmlUtils {
                 + emptyElementString.substring(boundary + 1);
     }
 
+    /**
+     * Converts a value's children to XML nodes. Kept for API compatibility: delegates to
+     * the cached variant with a fresh per-call type metadata cache.
+     *
+     * @param jNode             the value whose children are being converted
+     * @param allNamespaces     all namespace declarations seen so far (mutated)
+     * @param parentNamespaces  namespace declarations in scope from the parent chain
+     * @param options           the JSON-to-XML conversion options
+     * @param keyObj            the field key for array traversals, or {@code null}
+     * @param type              the declared type of {@code jNode}
+     * @param isParentSequence  whether the parent field carries an XSD sequence annotation
+     * @param isParentSequenceArray whether the parent is a sequence-annotated array
+     * @param parentModelGroupInfo  the parent's XSD model group metadata, if any
+     * @param parentElementInfo the parent's XSD element metadata, if any
+     * @return the children of the element being built, as an XML sequence
+     * @throws BError on XSD occurrence violations
+     */
     public static BXml traverseRecordAndGenerateXml(Object jNode, BMap<BString, BString> allNamespaces,
             BMap<BString, BString> parentNamespaces, BMap<BString, Object> options, Object keyObj, Type type,
             boolean isParentSequence, boolean isParentSequenceArray,
@@ -786,6 +857,16 @@ public class ToXmlUtils {
         return xNode;
     }
 
+    /**
+     * Reports whether an array-valued field annotated with {@code @xmldata:Any} holds
+     * record elements, in which case the array traversal names each element after its
+     * runtime record type instead of the field key.
+     *
+     * @param referredType the record type owning the field
+     * @param recordKey    the field name
+     * @param value        the array value of the field
+     * @return true if the field is {@code @Any}-annotated and holds record elements
+     */
     private static boolean isAnyArrayFieldKey(Type referredType, String recordKey, Object value) {
         if (!DataUtils.isFieldAnnotatedWithAny(referredType, recordKey)) {
             return false;
@@ -838,6 +919,16 @@ public class ToXmlUtils {
         return false;
     }
 
+    /**
+     * Resolves the element name for a field annotated with {@code @xmldata:Any}: the name
+     * of the record type of the value (or of the first record member of a union field
+     * type), falling back to the field key when no record type applies.
+     *
+     * @param referredType the record type owning the field
+     * @param recordKey    the field name
+     * @param k            the original field key
+     * @return the element name to emit for the field
+     */
     private static BString resolveAnyAnnotatedElementKey(Type referredType, String recordKey, BString k) {
         BString elementKey = k;
         if (referredType instanceof RecordType recordType &&
@@ -1040,6 +1131,13 @@ public class ToXmlUtils {
         return recordType.getName();
     }
 
+    /**
+     * Reports whether a value converts through the single-member path: maps with at most
+     * one entry, scalars, and arrays whose declared element type is not plain {@code json}.
+     *
+     * @param node the value being converted
+     * @return true if the single-member conversion path applies
+     */
     public static boolean isSingleRecordMember(Object node) {
         if (node instanceof BArray arrayNode) {
             // Intentionally compares the declared element type without resolving type
@@ -1141,6 +1239,16 @@ public class ToXmlUtils {
         return StringUtils.fromString(nameStr);
     }
 
+    /**
+     * Collects the XML attributes of a value: the parent's namespace declarations plus
+     * the value's attribute-prefixed fields, with namespace-qualified keys resolved.
+     *
+     * @param jsonTree         the value whose attribute fields are read
+     * @param options          the JSON-to-XML conversion options
+     * @param namespaces       all namespace declarations seen so far, for prefix lookups
+     * @param parentNamespaces namespace declarations inherited from the parent
+     * @return the attribute map for the element being built
+     */
     public static BMap<BString, BString> getAttributesMap(Object jsonTree,
                                                           BMap<BString, Object> options,
                                                           BMap<BString, BString> namespaces,
@@ -1217,6 +1325,15 @@ public class ToXmlUtils {
         return (long) startIndex;
     }
 
+    /**
+     * Collects the namespace declarations in scope for a value: the parent's declarations
+     * plus any {@code xmlns} attribute fields the value itself carries.
+     *
+     * @param jsonTree         the value whose namespace attribute fields are read
+     * @param options          the JSON-to-XML conversion options
+     * @param parentNamespaces namespace declarations inherited from the parent
+     * @return the namespace map in scope for the value
+     */
     public static BMap<BString, BString> getNamespacesMap(Object jsonTree,
                                                            BMap<BString, Object> options,
                                                            BMap<BString, BString> parentNamespaces) {

--- a/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
+++ b/native/src/main/java/io/ballerina/lib/data/xmldata/utils/ToXmlUtils.java
@@ -444,42 +444,33 @@ public class ToXmlUtils {
                 namespacesOfElem = getNamespacesMap(i, options, parentNamespaces);
                 addNamespaces(allNamespaces, namespacesOfElem);
                 int mark = out.length();
-                String shell;
-                if (options.get(Constants.ARRAY_ENTRY_TAG).toString().isEmpty()) {
-                    Type childType = getChildElementType(referredType, null);
-                    traverseRecordAndGenerateXmlString(out, i, allNamespaces, namespacesOfElem,
-                            options, keyObj, childType,
-                            isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
-                            typeMetadataCache, rootDeclarations);
-                    String elementTagKey = arrayEntryTagKey;
-                    boolean isAnyAnnotatedField = keyObj instanceof BString fieldNameBString &&
-                            fieldNameBString.getValue().startsWith("@Any:");
+                // The tree traversal also handles a configured array entry tag here; this path
+                // is only reachable through toXmlString, which always uses an empty entry tag.
+                Type childType = getChildElementType(referredType, null);
+                traverseRecordAndGenerateXmlString(out, i, allNamespaces, namespacesOfElem,
+                        options, keyObj, childType,
+                        isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
+                        typeMetadataCache, rootDeclarations);
+                String elementTagKey = arrayEntryTagKey;
+                boolean isAnyAnnotatedField = keyObj instanceof BString fieldNameBString &&
+                        fieldNameBString.getValue().startsWith("@Any:");
 
-                    if (isAnyAnnotatedField && i instanceof BMap) {
-                        Type elementValueType = TypeUtils.getType(i);
-                        Type referredElementType = TypeUtils.getReferredType(elementValueType);
-                        if (referredElementType instanceof RecordType recordValueType) {
-                            elementTagKey = getRecordTypeName(recordValueType);
-                        } else {
-                            // Fallback to declared child type if runtime type is not a RecordType
-                            Type referredChildType = TypeUtils.getReferredType(childType);
-                            if (referredChildType instanceof RecordType recordChildType) {
-                                elementTagKey = getRecordTypeName(recordChildType);
-                            }
+                if (isAnyAnnotatedField && i instanceof BMap) {
+                    Type elementValueType = TypeUtils.getType(i);
+                    Type referredElementType = TypeUtils.getReferredType(elementValueType);
+                    if (referredElementType instanceof RecordType recordValueType) {
+                        elementTagKey = getRecordTypeName(recordValueType);
+                    } else {
+                        // Fallback to declared child type if runtime type is not a RecordType
+                        Type referredChildType = TypeUtils.getReferredType(childType);
+                        if (referredChildType instanceof RecordType recordChildType) {
+                            elementTagKey = getRecordTypeName(recordChildType);
                         }
                     }
-                    shell = elementShellString(StringUtils.fromString(elementTagKey),
-                            allNamespaces, options, getAttributesMap(i, options, allNamespaces, parentNamespaces),
-                            parentNamespaces, rootDeclarations);
-                } else {
-                    traverseRecordAndGenerateXmlString(out, i, allNamespaces, namespacesOfElem,
-                            options, null, getChildElementType(referredType, null),
-                            isParentSequence, isParentSequenceArray, parentModelGroupInfo, parentElementInfo,
-                            typeMetadataCache, rootDeclarations);
-                    shell = elementShellString(StringUtils.fromString(arrayEntryTagKey),
-                            allNamespaces, options, getAttributesMap(i, options, allNamespaces, parentNamespaces),
-                            parentNamespaces, rootDeclarations);
                 }
+                String shell = elementShellString(StringUtils.fromString(elementTagKey),
+                        allNamespaces, options, getAttributesMap(i, options, allNamespaces, parentNamespaces),
+                        parentNamespaces, rootDeclarations);
                 if (!isParentSequenceArray) {
                     insertElementAround(out, mark, shell);
                 }
@@ -563,14 +554,9 @@ public class ToXmlUtils {
             out.append("</").append(qualifiedName).append(">");
             return;
         }
-        // <tag ...></tag> form: '<' never occurs unescaped inside attribute values, so the
-        // first "></" is the boundary between the open and close tags.
-        int boundary = shellString.indexOf("></");
-        if (boundary == -1) {
-            throw new IllegalStateException("unexpected empty element serialization: " + shellString);
-        }
-        out.insert(mark, shellString.substring(0, boundary + 1));
-        out.append(shellString.substring(boundary + 1));
+        String childrenString = out.substring(mark);
+        out.setLength(mark);
+        out.append(spliceChildrenIntoElement(shellString, childrenString));
     }
 
     /**


### PR DESCRIPTION
## Purpose
`toXml` is slow on large payloads and needs a heap many times the output size, because it materializes the whole `BXml` tree. Converting a record with a 10K-element array (19 MB of XML) takes ~11s in ~704 MB minimum heap, growing quadratically in time and linearly in heap with size. Resolves ballerina-platform/ballerina-library#9027 (Parts A and B).


## Approach
**Part A** — four small changes in `ToXmlUtils.java`:
- Append children linearly instead of `Concat.concat` per child (was O(n²) — every append re-copied all previous children).
- Replace a whole-tree `ValueUtils.convert` whose result was only `.size()`-checked with direct type checks.
- Gate `getAttributesMap`/`getNamespacesMap` with `instanceof BMap` so scalar fields stop taking an exception-throwing convert path (~500K swallowed exceptions per large payload).
- Cache the four annotation-derived metadata maps once per type per conversion (were rebuilt on every recursive call).

**Part B** — `toXmlString`:
- The traversal writes markup into one shared `StringBuilder`; each element's open tag comes from serializing an *empty* element through the existing `getElementFromRecordMember` logic, then splicing it around the already-written children — so names, attributes, prefixes, and escaping stay faithful to the tree serializer.
- In-scope namespace suppression is delegated to the runtime serializer itself: shells are serialized inside a wrapper element carrying the ancestor declarations, then unwrapped.
- Fast paths skip the serializer round trip for attribute-less plain-named elements and text with no escapable characters; the per-call `TypeCreator.createMapType` in `getAttributesMap`/`getNamespacesMap` is replaced with the existing `Constants.JSON_MAP_TYPE` (this also benefits `toXml`).

## Automation tests
- Full suite: **690 passing / 0 failing** (676 existing + 14 new `toXmlString` parity tests).
- Part A output verified **byte-identical to released 1.6.3** by SHA-256 at 1/3/100/10K-record payloads.
- Part B verified `toXmlString(v, opts) == toXml(v, opts).toString()` across 141 fuzzed assertions reusing the module's own test types: nested/prefixed/default namespaces, `@Name`/`@Namespace`/`@Attribute`, `@Any` fields, XSD sequences/choices, unions, ref types, custom `Options`, and error cases (identical error messages).
- Benchmarks (JDK 21, G1, 19 MB XML at 10K records):

| Payload | `toXml` 1.6.3 | `toXml` patched | `toXmlString` |
|---|---|---|---|
| 10K records, time @1 GB | 11.4 s | 6.5 s | 6.0 s |
| 10K records, min heap | ~704 MB | ~704 MB | ~192 MB  |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved `xmldata:toXml` performance and memory usage for large payloads.
- Added `xmldata:toXmlString` to serialize records and maps directly to XML text without creating a `BXml` tree.
- Preserved XML output and behavior across namespaces, attributes, escaping, unions, reference types, custom options, and error cases.
- Added metadata caching, linear child accumulation, direct scalar checks, and shared conversion logic.
- Added comprehensive parity and edge-case tests for `toXmlString`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->